### PR TITLE
feat!: PostgreSQL service should have no default plans

### DIFF
--- a/acceptance-tests/helpers/brokers/env.go
+++ b/acceptance-tests/helpers/brokers/env.go
@@ -39,6 +39,7 @@ func (b Broker) env() []apps.EnvVar {
 		apps.EnvVar{Name: "ENCRYPTION_ENABLED", Value: true},
 		apps.EnvVar{Name: "ENCRYPTION_PASSWORDS", Value: b.secrets},
 		apps.EnvVar{Name: "BROKERPAK_UPDATES_ENABLED", Value: true},
+		apps.EnvVar{Name: "GSB_SERVICE_CSB_GOOGLE_POSTGRES_PLANS", Value: `[{"name":"small","id":"85b27a04-8695-11ea-818a-274131861b81","description":"PostgreSQL v11, shared CPU, minumum 0.6GB ram, 10GB storage","display_name":"small","cores":0.6,"postgres_version":"POSTGRES_11","storage_gb":10},{"name":"medium","id":"b41ee300-8695-11ea-87df-cfcb8aecf3bc","description":"PostgreSQL v11, shared CPU, minumum 1.7GB ram, 20GB storage","display_name":"medium","cores":1.7,"postgres_version":"POSTGRES_11","storage_gb":20},{"name":"large","id":"2a57527e-b025-11ea-b643-bf3bcf6d055a","description":"PostgreSQL v11, minumum 8 cores, minumum 8GB ram, 50GB storage","display_name":"large","cores":8,"postgres_version":"POSTGRES_11","storage_gb":50}]`},
 	)
 
 	return append(result, b.envExtras...)

--- a/docs/draft-release-notes.md
+++ b/docs/draft-release-notes.md
@@ -1,5 +1,8 @@
 ## Release notes for next release:
 
+### Breaking changes:
+- The default plans for PostgreSQL have been removed. In order to successfully deploy a broker, plans must be defined via the `GSB_SERVICE_CSB_GOOGLE_POSTGRES_PLANS` environment variable.
+
 ### New feature:
 
 

--- a/google-postgresql.yml
+++ b/google-postgresql.yml
@@ -23,31 +23,6 @@ documentation_url: https://cloud.google.com/sql/docs/postgres
 support_url: https://cloud.google.com/support/
 tags: [gcp, postgresql, postgres]
 plan_updateable: true
-plans:
-- name: small
-  id: 85b27a04-8695-11ea-818a-274131861b81
-  description: 'PostgreSQL v11, shared CPU, minumum 0.6GB ram, 10GB storage'
-  display_name: "small"
-  properties:
-    cores: 0.6
-    postgres_version: "POSTGRES_11"
-    storage_gb: 10
-- name: medium
-  id: b41ee300-8695-11ea-87df-cfcb8aecf3bc
-  description: 'PostgreSQL v11, shared CPU, minumum 1.7GB ram, 20GB storage'
-  display_name: "medium"
-  properties:
-    cores: 1.7
-    postgres_version: "POSTGRES_11"
-    storage_gb: 20
-- name: large
-  id: 2a57527e-b025-11ea-b643-bf3bcf6d055a
-  description: 'PostgreSQL v11, minumum 8 cores, minumum 8GB ram, 50GB storage'
-  display_name: "large"
-  properties:
-    cores: 8
-    postgres_version: "POSTGRES_11"
-    storage_gb: 50
 provision:
   plan_inputs:
   user_inputs:

--- a/scripts/push-broker.sh
+++ b/scripts/push-broker.sh
@@ -96,6 +96,11 @@ if [[ ${GSB_DEBUG} ]]; then
   cf set-env "${APP_NAME}" GSB_DEBUG "${GSB_DEBUG}"
 fi
 
+if [[ -z "$GSB_SERVICE_CSB_GOOGLE_POSTGRES_PLANS" ]]; then
+  GSB_SERVICE_CSB_GOOGLE_POSTGRES_PLANS='[{"name":"small","id":"85b27a04-8695-11ea-818a-274131861b81","description":"PostgreSQL v11, shared CPU, minumum 0.6GB ram, 10GB storage","display_name":"small","cores":0.6,"postgres_version":"POSTGRES_11","storage_gb":10},{"name":"medium","id":"b41ee300-8695-11ea-87df-cfcb8aecf3bc","description":"PostgreSQL v11, shared CPU, minumum 1.7GB ram, 20GB storage","display_name":"medium","cores":1.7,"postgres_version":"POSTGRES_11","storage_gb":20},{"name":"large","id":"2a57527e-b025-11ea-b643-bf3bcf6d055a","description":"PostgreSQL v11, minumum 8 cores, minumum 8GB ram, 50GB storage","display_name":"large","cores":8,"postgres_version":"POSTGRES_11","storage_gb":50}]'
+fi
+cf set-env "${APP_NAME}" GSB_SERVICE_CSB_GOOGLE_POSTGRES_PLANS "${GSB_SERVICE_CSB_GOOGLE_POSTGRES_PLANS}"
+
 if [[ -z ${MSYQL_INSTANCE} ]]; then
   MSYQL_INSTANCE=csb-sql
 fi


### PR DESCRIPTION
BREAKING CHANGE:
In order to facilitate configuration of plans, the default plans for
PostgreSQL have been removed. Plans should be specified via the
environment variable GSB_SERVICE_CSB_GOOGLE_POSTGRES_PLANS. This allows
the default plans to be completely removed, wheras previously it was
only possible to add additional plans.

[#181059527](https://www.pivotaltracker.com/story/show/181059527)

### Checklist:

* [X] Have you added Draft Release Notes in `docs/draft-release-notes.md`?
* [X] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

