### PR TITLE
docs: beta services now disabled by default by csb

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -60,11 +60,13 @@ The broker supports passing credentials to apps via [credhub references](https:/
 Brokerpak configuration values:
 | Environment Variable | Config File Value | Type | Description |
 |----------------------|------|-------------|------------------|
-| <tt>GSB_BROKERPAK_BUILTIN_PATH</tt> | brokerpak.builtin.path | string | <p>Path to search for .brokerpak files, default: <code>./</code></p>|
+|<tt>GSB_BROKERPAK_BUILTIN_PATH</tt> | brokerpak.builtin.path | string | <p>Path to search for .brokerpak files, default: <code>./</code></p>|
 |<tt>GSB_BROKERPAK_CONFIG</tt>|brokerpak.config| string | JSON global config for broker pak services|
 |<tt>GSB_PROVISION_DEFAULTS</tt>|provision.defaults| string | JSON global provision defaults|
 |<tt>GSB_SERVICE_*SERVICE_NAME*_PROVISION_DEFAULTS</tt>|service.*service-name*.provision.defaults| string | JSON provision defaults override for *service-name*|
 |<tt>GSB_SERVICE_*SERVICE_NAME*_PLANS</tt>|service.*service-name*.plans| string | JSON plan collection to augment plans for *service-name*|
+|<tt>GSB_COMPATIBILITY_ENABLE_BETA_SERVICES</tt>| compatibility.enable-beta-services | bool | Enable services tagged with `beta`. Default: `false` |
+
 
 ## Google Configuration
 

--- a/docs/draft-release-notes.md
+++ b/docs/draft-release-notes.md
@@ -6,6 +6,7 @@
 
 ### New feature:
 - The `BROKERPAK_UPDATES_ENABLED` feature flag is always turned on, so the HCL used when managing a service instance is always the latest taken from the brokerpak.
+- Beta tagged services are now disabled by CSB by default. To enable these services the following env var must be set: `GSB_COMPATIBILITY_ENABLE_BETA_SERVICES=true`
 
 ### Fix:
 - All service offerings and plans are highlighted to be at a Beta lifecycle state.


### PR DESCRIPTION
Adds docs for the new `beta` feature flag work done on CSB.

[#181267511](https://www.pivotaltracker.com/story/show/181267511)

### Checklist:

* [x] Have you added Draft Release Notes in `docs/draft-release-notes.md`?
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

