### PR TITLE
fix: [postgres] bind user is deleted during unbind

### DIFF
--- a/acceptance-tests/apps/postgresqlapp/internal/app/app.go
+++ b/acceptance-tests/apps/postgresqlapp/internal/app/app.go
@@ -3,10 +3,12 @@ package app
 import (
 	"database/sql"
 	"fmt"
-	"github.com/gorilla/mux"
-	_ "github.com/jackc/pgx/v4/stdlib"
 	"log"
 	"net/http"
+	"regexp"
+
+	"github.com/gorilla/mux"
+	_ "github.com/jackc/pgx/v4/stdlib"
 )
 
 const (
@@ -20,8 +22,10 @@ func App(uri string) *mux.Router {
 
 	r := mux.NewRouter()
 	r.HandleFunc("/", aliveness).Methods(http.MethodHead, http.MethodGet)
-	r.HandleFunc("/{key}", handleSet(db)).Methods(http.MethodPut)
-	r.HandleFunc("/{key}", handleGet(db)).Methods(http.MethodGet)
+	r.HandleFunc("/{schema}", handleCreateSchema(db)).Methods(http.MethodPut)
+	r.HandleFunc("/{schema}", handleDropSchema(db)).Methods(http.MethodDelete)
+	r.HandleFunc("/{schema}/{key}", handleSet(db)).Methods(http.MethodPut)
+	r.HandleFunc("/{schema}/{key}", handleGet(db)).Methods(http.MethodGet)
 
 	return r
 }
@@ -55,4 +59,21 @@ func fail(w http.ResponseWriter, code int, format string, a ...interface{}) {
 	msg := fmt.Sprintf(format, a...)
 	log.Println(msg)
 	http.Error(w, msg, code)
+}
+
+func schemaName(r *http.Request) (string, error) {
+	schema, ok := mux.Vars(r)["schema"]
+
+	switch {
+	case !ok:
+		return "", fmt.Errorf("schema missing")
+	case len(schema) > 50:
+		return "", fmt.Errorf("schema name too long")
+	case len(schema) == 0:
+		return "", fmt.Errorf("schema name cannot be zero length")
+	case !regexp.MustCompile(`^[a-zA-Z0-9]+$`).MatchString(schema):
+		return "", fmt.Errorf("schema name contains invalid characters")
+	default:
+		return schema, nil
+	}
 }

--- a/acceptance-tests/apps/postgresqlapp/internal/app/create_schema.go
+++ b/acceptance-tests/apps/postgresqlapp/internal/app/create_schema.go
@@ -1,0 +1,47 @@
+package app
+
+import (
+	"database/sql"
+	"fmt"
+	"log"
+	"net/http"
+)
+
+func handleCreateSchema(db *sql.DB) func(w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		log.Println("Handling create schema.")
+
+		schema, err := schemaName(r)
+		if err != nil {
+			fail(w, http.StatusInternalServerError, "Schema name error: %s", err)
+			return
+		}
+
+		_, err = db.Exec(fmt.Sprintf(`CREATE SCHEMA %s`, schema))
+		if err != nil {
+			fail(w, http.StatusBadRequest, "Error creating schema: %s", err)
+			return
+		}
+
+		_, err = db.Exec(fmt.Sprintf(`GRANT ALL ON SCHEMA %s TO PUBLIC`, schema))
+		if err != nil {
+			fail(w, http.StatusBadRequest, "Error granting schema permissions: %s", err)
+			return
+		}
+
+		_, err = db.Exec(fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s.%s (%s VARCHAR(255) NOT NULL, %s VARCHAR(255) NOT NULL)`, schema, tableName, keyColumn, valueColumn))
+		if err != nil {
+			fail(w, http.StatusBadRequest, "Error creating table: %s", err)
+			return
+		}
+
+		_, err = db.Exec(fmt.Sprintf(`GRANT ALL ON TABLE %s.%s TO PUBLIC`, schema, tableName))
+		if err != nil {
+			fail(w, http.StatusBadRequest, "Error granting table permissions: %s", err)
+			return
+		}
+
+		w.WriteHeader(http.StatusCreated)
+		log.Printf("Schema %q created", schema)
+	}
+}

--- a/acceptance-tests/apps/postgresqlapp/internal/app/drop_schema.go
+++ b/acceptance-tests/apps/postgresqlapp/internal/app/drop_schema.go
@@ -1,0 +1,26 @@
+package app
+import (
+	"database/sql"
+	"fmt"
+	"log"
+	"net/http"
+)
+func handleDropSchema(db *sql.DB) func(w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		log.Println("Handling drop schema.")
+		schema, err := schemaName(r)
+		if err != nil {
+			fail(w, http.StatusInternalServerError, "Schema name error: %s\n", err)
+			return
+		}
+
+		_, err = db.Exec(fmt.Sprintf(`DROP SCHEMA %s CASCADE`, schema))
+		if err != nil {
+			fail(w, http.StatusBadRequest, "Error dropping schema: %s", err)
+			return
+		}
+
+		w.WriteHeader(http.StatusNoContent)
+		log.Printf("Schema %q dropped", schema)
+	}
+}

--- a/acceptance-tests/helpers/apps/http.go
+++ b/acceptance-tests/helpers/apps/http.go
@@ -30,6 +30,7 @@ func (a *App) PUT(data, format string, s ...interface{}) {
 	fmt.Fprintf(GinkgoWriter, "HTTP PUT: %s\n", url)
 	fmt.Fprintf(GinkgoWriter, "Sending data: %s\n", data)
 	request, err := http.NewRequest(http.MethodPut, url, strings.NewReader(data))
+	Expect(err).NotTo(HaveOccurred())
 	request.Header.Set("Content-Type", "text/html")
 	response, err := http.DefaultClient.Do(request)
 	Expect(err).NotTo(HaveOccurred())

--- a/docs/draft-release-notes.md
+++ b/docs/draft-release-notes.md
@@ -12,3 +12,4 @@
 ### Fix:
 - All service offerings and plans are highlighted to be at a Beta lifecycle state.
 - Fixed typo `defualt` => `default` in the postgres service, now the size of storage volume should default to 10 GB
+- Bind users are now deleted on unbind operation and the ownership of the objects they created is passed on to a "provision_user"

--- a/google-postgresql.yml
+++ b/google-postgresql.yml
@@ -126,12 +126,12 @@ provision:
     overwrite: true
     type: number
   template_refs:
-    provider: terraform/cloudsql/provision/provider.tf
-    versions: terraform/cloudsql/provision/versions.tf
-    main: terraform/cloudsql/provision/main.tf
-    data: terraform/cloudsql/provision/data.tf
-    variables: terraform/cloudsql/provision/variables.tf
-    outputs: terraform/cloudsql/provision/outputs.tf
+    provider: terraform/cloudsql/provisionpostgresql/provider.tf
+    versions: terraform/cloudsql/provisionpostgresql/versions.tf
+    main: terraform/cloudsql/provisionpostgresql/main.tf
+    data: terraform/cloudsql/provisionpostgresql/data.tf
+    variables: terraform/cloudsql/provisionpostgresql/variables.tf
+    outputs: terraform/cloudsql/provisionpostgresql/outputs.tf
   outputs:
   - field_name: name
     type: string

--- a/terraform/cloudsql/bindpostgresql/main.tf
+++ b/terraform/cloudsql/bindpostgresql/main.tf
@@ -16,23 +16,7 @@ resource "postgresql_role" "new_user" {
   name                = random_string.username.result
   login               = true
   password            = random_password.password.result
-  skip_reassign_owned = true
-  skip_drop_role      = true
-}
-
-resource "postgresql_grant" "db_access" {
-  depends_on  = [postgresql_role.new_user]
-  database    = var.db_name
-  role        = postgresql_role.new_user.name
-  object_type = "database"
-  privileges  = ["ALL"]
-}
-
-resource "postgresql_grant" "table_access" {
-  depends_on  = [postgresql_role.new_user]
-  database    = var.db_name
-  role        = postgresql_role.new_user.name
-  schema      = "public"
-  object_type = "table"
-  privileges  = ["ALL"]
+  roles               = [
+    var.admin_username
+  ]
 }

--- a/terraform/cloudsql/bindpostgresql/outputs.tf
+++ b/terraform/cloudsql/bindpostgresql/outputs.tf
@@ -12,14 +12,6 @@ output "uri" {
     var.port,
   var.db_name)
 }
-/* output jdbcUrl {
-  value = format("jdbc:postgresql://%s:%d/%s?user=%s\u0026password=%s\u0026useSSL=false",
-                  var.hostname,
-                  var.port,
-                  var.db_name,
-                  random_string.username.result,
-                  random_password.password.result)
-} */
 
 output "jdbcUrl" {
   sensitive = true

--- a/terraform/cloudsql/provisionpostgresql/data.tf
+++ b/terraform/cloudsql/provisionpostgresql/data.tf
@@ -1,0 +1,19 @@
+data "google_compute_network" "authorized-network" {
+  name = var.authorized_network
+}
+
+locals {
+  service_tiers = {
+    // https://cloud.google.com/sql/pricing#2nd-gen-pricing
+    1   = "db-n1-standard-1"
+    2   = "db-n1-standard-2"
+    4   = "db-n1-standard-4"
+    8   = "db-n1-standard-8"
+    16  = "db-n1-standard-16"
+    32  = "db-n1-standard-32"
+    64  = "db-n1-standard-64"
+    0.6 = "db-f1-micro"
+    1.7 = "db-g1-small"
+  }
+  authorized_network_id = length(var.authorized_network_id) > 0 ? var.authorized_network_id : data.google_compute_network.authorized-network.self_link
+}

--- a/terraform/cloudsql/provisionpostgresql/main.tf
+++ b/terraform/cloudsql/provisionpostgresql/main.tf
@@ -1,0 +1,77 @@
+resource "google_sql_database_instance" "instance" {
+  name             = var.instance_name
+  database_version = var.database_version
+  region           = var.region
+
+  settings {
+    tier        = local.service_tiers[var.cores]
+    disk_size   = var.storage_gb
+    user_labels = var.labels
+
+    ip_configuration {
+      ipv4_enabled    = false
+      private_network = local.authorized_network_id
+      #require_ssl = var.use_tls
+    }
+  }
+
+  deletion_protection = false
+}
+
+resource "google_sql_database" "database" {
+  name     = var.db_name
+  instance = google_sql_database_instance.instance.name
+}
+
+resource "random_string" "username" {
+  length  = 16
+  special = false
+}
+
+resource "random_password" "password" {
+  length           = 16
+  special          = true
+  override_special = "_@"
+}
+
+resource "google_sql_user" "admin_user" {
+  name     = random_string.username.result
+  instance = google_sql_database_instance.instance.name
+  password = random_password.password.result
+  deletion_policy="ABANDON"
+}
+
+resource "random_string" "createrole_username" {
+  length  = 16
+  special = false
+}
+resource "random_password" "createrole_password" {
+  length           = 16
+  special          = true
+  override_special = "_@"
+}
+
+resource "postgresql_role" "createrole_user" {
+  depends_on  = [google_sql_user.admin_user]
+  name                = random_string.createrole_username.result
+  password            = random_password.createrole_password.result
+  login               = true
+  create_role         = true
+}
+
+resource "postgresql_grant" "db_access" {
+  depends_on  = [postgresql_role.createrole_user]
+  database    = var.db_name
+  role        = postgresql_role.createrole_user.name
+  object_type = "database"
+  privileges  = ["ALL"]
+}
+
+resource "postgresql_grant" "table_access" {
+  depends_on  = [postgresql_role.createrole_user]
+  database    = var.db_name
+  role        = postgresql_role.createrole_user.name
+  schema      = "public"
+  object_type = "table"
+  privileges  = ["ALL"]
+}

--- a/terraform/cloudsql/provisionpostgresql/outputs.tf
+++ b/terraform/cloudsql/provisionpostgresql/outputs.tf
@@ -1,0 +1,10 @@
+output "name" { value = google_sql_database.database.name }
+output "hostname" { value = google_sql_database_instance.instance.first_ip_address }
+
+output "port" { value = var.db_port }
+output "username" { value = postgresql_role.createrole_user.name }
+output "password" {
+  sensitive = true
+  value     = postgresql_role.createrole_user.password
+}
+output "use_tls" { value = false }

--- a/terraform/cloudsql/provisionpostgresql/provider.tf
+++ b/terraform/cloudsql/provisionpostgresql/provider.tf
@@ -1,0 +1,14 @@
+provider "google" {
+  credentials = var.credentials
+  project     = var.project
+}
+
+provider "postgresql" {
+  host      = google_sql_database_instance.instance.first_ip_address
+  port      = 5432
+  username  = google_sql_user.admin_user.name
+  password  = google_sql_user.admin_user.password
+  superuser = false
+  database  = google_sql_database.database.name
+  sslmode   = "disable"
+}

--- a/terraform/cloudsql/provisionpostgresql/variables.tf
+++ b/terraform/cloudsql/provisionpostgresql/variables.tf
@@ -1,0 +1,15 @@
+variable "cores" { type = number }
+variable "authorized_network" { type = string }
+variable "authorized_network_id" { type = string }
+variable "instance_name" { type = string }
+variable "db_name" { type = string }
+
+variable "region" { type = string }
+variable "labels" { type = map(any) }
+variable "storage_gb" { type = number }
+variable "database_version" { type = string }
+variable "db_port" { type = number }
+
+variable "credentials" { type = string }
+variable "project" { type = string }
+#variable use_tls { type = bool }

--- a/terraform/cloudsql/provisionpostgresql/versions.tf
+++ b/terraform/cloudsql/provisionpostgresql/versions.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">=4.8.0"
+    }
+    
+    postgresql = {
+      source  = "cyrilgdn/postgresql"
+      version = ">=1.15.0"
+    }
+  }
+}


### PR DESCRIPTION
On provision we create a user that is then used to create the bind users. This user is also set as the bind user role and it  also takes ownership of all the objects that the bind user had. That allows other users to manipulate the objects after an unbind has happen.
Ideally we would like to create a non-login user for this purpose but there a limitations of using the tf providers to create that flow.

[#181525059](https://www.pivotaltracker.com/story/show/181525059)
[#181266428](https://www.pivotaltracker.com/story/show/181266428)

### Checklist:

* [ ] Have you added Draft Release Notes in `docs/draft-release-notes.md`?
* [ ] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

