### PR TITLE
chore: Set mysql and postgres ports as local vars

### DIFF
--- a/google-mysql.yml
+++ b/google-mysql.yml
@@ -142,10 +142,6 @@ provision:
     default: ${mysql_version}
     overwrite: true
     type: string
-  - name: db_port
-    default: 3306
-    overwrite: true
-    type: number
   template_refs:
     provider: terraform/cloudsql/mysql/provision/provider.tf
     versions: terraform/cloudsql/mysql/provision/versions.tf
@@ -160,9 +156,6 @@ provision:
   - field_name: hostname
     type: string
     details: Hostname or IP address of the exposed mysql endpoint used by clients to connect to the service.
-  - field_name: port
-    type: integer
-    details: The port number of the exposed mysql instance.
   - field_name: username
     type: string
     details: The username to authenticate to the database instance.
@@ -183,10 +176,6 @@ bind:
   - name: mysql_hostname
     type: string
     default: ${instance.details["hostname"]}
-    overwrite: true
-  - name: mysql_port
-    type: integer
-    default: ${instance.details["port"]}
     overwrite: true
   - name: admin_username
     type: string
@@ -216,6 +205,9 @@ bind:
   - field_name: uri
     type: string
     details: The uri to connect to the database instance and database.
+  - field_name: port
+    type: integer
+    details: The port number of the exposed mysql instance.
   - field_name: jdbcUrl
     type: string
     details: The jdbc url to connect to the database instance and database.

--- a/google-postgresql.yml
+++ b/google-postgresql.yml
@@ -131,10 +131,6 @@ provision:
     default: ${postgres_version}
     overwrite: true
     type: string
-  - name: db_port
-    default: 5432
-    overwrite: true
-    type: number
   template_refs:
     provider: terraform/cloudsql/postgresql/provision/provider.tf
     versions: terraform/cloudsql/postgresql/provision/versions.tf
@@ -149,9 +145,6 @@ provision:
   - field_name: hostname
     type: string
     details: Hostname or IP address of the exposed postgres endpoint used by clients to connect to the service.
-  - field_name: port
-    type: integer
-    details: The port number of the exposed postgres instance.
   - field_name: username
     type: string
     details: The username to authenticate to the database instance.
@@ -172,10 +165,6 @@ bind:
   - name: hostname
     type: string
     default: ${instance.details["hostname"]}
-    overwrite: true
-  - name: port
-    type: number
-    default: ${instance.details["port"]}
     overwrite: true
   - name: admin_username
     type: string
@@ -205,6 +194,9 @@ bind:
   - field_name: uri
     type: string
     details: The uri to connect to the database instance and database.
+  - field_name: port
+    type: integer
+    details: The port number of the exposed postgres instance.
   - field_name: jdbcUrl
     type: string
     details: The jdbc url to connect to the database instance and database.

--- a/integration-tests/mysql_test.go
+++ b/integration-tests/mysql_test.go
@@ -50,15 +50,6 @@ var _ = Describe("Mysql", func() {
 
 			Expect(err).To(MatchError(ContainSubstring("plan defined properties cannot be changed: cores")))
 		})
-		It("configures the port for postgres", func() {
-			broker.Provision("csb-google-mysql", "small", nil)
-
-			invocations, err := mockTerraform.ApplyInvocations()
-			Expect(err).NotTo(HaveOccurred())
-			Expect(invocations).To(HaveLen(1))
-			Expect(invocations[0].TFVars()).To(HaveKeyWithValue("db_port", float64(3306)))
-		})
-
 	})
 
 	Describe("property validations", func() {

--- a/integration-tests/postgres_test.go
+++ b/integration-tests/postgres_test.go
@@ -204,17 +204,6 @@ var _ = Describe("postgres", func() {
 		})
 	})
 
-	Context("port is configured", func() {
-		It("configures the port for postgres", func() {
-			broker.Provision("csb-google-postgres", postgresNoOverridesPlan["name"].(string), map[string]interface{}{"cores": 1})
-
-			invocations, err := mockTerraform.ApplyInvocations()
-			Expect(err).NotTo(HaveOccurred())
-			Expect(invocations).To(HaveLen(1))
-			Expect(invocations[0].TFVars()).To(HaveKeyWithValue("db_port", float64(5432)))
-		})
-	})
-
 	Context("bind a service ", func() {
 		It("return the bind values from terraform output", func() {
 			mockTerraform.ReturnTFState([]testframework.TFStateValue{
@@ -222,7 +211,6 @@ var _ = Describe("postgres", func() {
 				{"use_tls", "bool", false},
 				{"username", "string", "create.test.username"},
 				{"password", "string", "create.test.password"},
-				{"port", "int", 9999},
 				{"name", "string", "create.test.instancename"},
 			})
 
@@ -244,7 +232,6 @@ var _ = Describe("postgres", func() {
 				"jdbcUrl":  "bind.test.jdbcUrl",
 				"name":     "create.test.instancename",
 				"password": "bind.test.password",
-				"port":     float64(9999),
 				"uri":      "bind.test.uri",
 				"use_tls":  false,
 			}))

--- a/integration-tests/results/mysql-result.json
+++ b/integration-tests/results/mysql-result.json
@@ -13,6 +13,5 @@
   },
   "project": "broker-gcp-project",
   "region": "us-central1",
-  "storage_gb": 10,
-  "db_port": 3306
+  "storage_gb": 10
 }

--- a/terraform/cloudsql/mysql/bind/outputs.tf
+++ b/terraform/cloudsql/mysql/bind/outputs.tf
@@ -9,14 +9,15 @@ output "uri" {
     random_string.username.result,
     random_password.password.result,
     var.mysql_hostname,
-    var.mysql_port,
+    locals.port,
   var.mysql_db_name)
 }
+output "port" { value = locals.port } 
 output "jdbcUrl" {
   sensitive = true
   value = format("jdbc:mysql://%s:%d/%s?user=%s\u0026password=%s\u0026useSSL=%v",
     var.mysql_hostname,
-    var.mysql_port,
+    locals.port,
     var.mysql_db_name,
     mysql_user.newuser.user,
     random_password.password.result,

--- a/terraform/cloudsql/mysql/bind/provider.tf
+++ b/terraform/cloudsql/mysql/bind/provider.tf
@@ -1,5 +1,5 @@
 provider "mysql" {
-  endpoint = format("%s:%d", var.mysql_hostname, var.mysql_port)
+  endpoint = format("%s:%d", var.mysql_hostname, locals.port)
   username = var.admin_username
   password = var.admin_password
 }

--- a/terraform/cloudsql/mysql/bind/variables.tf
+++ b/terraform/cloudsql/mysql/bind/variables.tf
@@ -1,6 +1,9 @@
 variable "mysql_db_name" { type = string }
 variable "mysql_hostname" { type = string }
-variable "mysql_port" { type = number }
 variable "admin_username" { type = string }
 variable "admin_password" { type = string }
 variable "use_tls" { type = bool }
+
+locals {
+  port = 3306
+}

--- a/terraform/cloudsql/mysql/provision/outputs.tf
+++ b/terraform/cloudsql/mysql/provision/outputs.tf
@@ -1,7 +1,6 @@
 output "name" { value = google_sql_database.database.name }
 output "hostname" { value = google_sql_database_instance.instance.first_ip_address }
 
-output "port" { value = var.db_port }
 output "username" { value = google_sql_user.admin_user.name }
 output "password" {
   sensitive = true

--- a/terraform/cloudsql/mysql/provision/variables.tf
+++ b/terraform/cloudsql/mysql/provision/variables.tf
@@ -8,7 +8,6 @@ variable "region" { type = string }
 variable "labels" { type = map(any) }
 variable "storage_gb" { type = number }
 variable "database_version" { type = string }
-variable "db_port" { type = number }
 
 variable "credentials" { type = string }
 variable "project" { type = string }

--- a/terraform/cloudsql/postgresql/bind/outputs.tf
+++ b/terraform/cloudsql/postgresql/bind/outputs.tf
@@ -9,7 +9,7 @@ output "uri" {
     random_string.username.result,
     random_password.password.result,
     var.hostname,
-    var.port,
+    locals.port,
   locals.db_name)
 }
 output "port" { value = locals.port } 

--- a/terraform/cloudsql/postgresql/bind/outputs.tf
+++ b/terraform/cloudsql/postgresql/bind/outputs.tf
@@ -10,15 +10,15 @@ output "uri" {
     random_password.password.result,
     var.hostname,
     var.port,
-  var.db_name)
+  locals.db_name)
 }
-
+output "port" { value = locals.port } 
 output "jdbcUrl" {
   sensitive = true
   value = format("jdbc:%s://%s:%s/%s?user=%s\u0026password=%s\u0026verifyServerCertificate=true\u0026useSSL=%v\u0026requireSSL=false",
     "postgresql",
     var.hostname,
-    var.port,
+    locals.port,
     var.db_name,
     random_string.username.result,
     random_password.password.result,

--- a/terraform/cloudsql/postgresql/bind/provider.tf
+++ b/terraform/cloudsql/postgresql/bind/provider.tf
@@ -1,6 +1,6 @@
 provider "postgresql" {
   host      = var.hostname
-  port      = var.port
+  port      = locals.port
   username  = var.admin_username
   password  = var.admin_password
   superuser = false

--- a/terraform/cloudsql/postgresql/bind/variables.tf
+++ b/terraform/cloudsql/postgresql/bind/variables.tf
@@ -1,6 +1,9 @@
 variable "db_name" { type = string }
 variable "hostname" { type = string }
-variable "port" { type = number }
 variable "admin_username" { type = string }
 variable "admin_password" { type = string }
 variable "use_tls" { type = bool }
+
+locals {
+  port = 5432
+}

--- a/terraform/cloudsql/postgresql/provision/outputs.tf
+++ b/terraform/cloudsql/postgresql/provision/outputs.tf
@@ -1,7 +1,6 @@
 output "name" { value = google_sql_database.database.name }
 output "hostname" { value = google_sql_database_instance.instance.first_ip_address }
 
-output "port" { value = var.db_port }
 output "username" { value = postgresql_role.createrole_user.name }
 output "password" {
   sensitive = true

--- a/terraform/cloudsql/postgresql/provision/variables.tf
+++ b/terraform/cloudsql/postgresql/provision/variables.tf
@@ -10,7 +10,6 @@ variable "region" { type = string }
 variable "labels" { type = map(any) }
 variable "storage_gb" { type = number }
 variable "database_version" { type = string }
-variable "db_port" { type = number }
 
 variable "credentials" { type = string }
 variable "project" { type = string }


### PR DESCRIPTION
Since the tf definitions are split the ports dont need to be passed from provision step anymore

### Checklist:

* [ ] Have you added Draft Release Notes in `docs/draft-release-notes.md`?
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

