### PR TITLE
test: fix up upgrade tests for new starting point

### DIFF
--- a/acceptance-tests/helpers/brokers/create.go
+++ b/acceptance-tests/helpers/brokers/create.go
@@ -65,18 +65,6 @@ func WithEnv(env ...apps.EnvVar) Option {
 	}
 }
 
-func WithReleaseEnv() Option {
-	return func(b *Broker) {
-		b.envExtras = append(b.envExtras, b.releaseEnv()...)
-	}
-}
-
-func WithLatestEnv() Option {
-	return func(b *Broker) {
-		b.envExtras = append(b.envExtras, b.latestEnv()...)
-	}
-}
-
 func WithUsername(username string) Option {
 	return func(b *Broker) {
 		b.username = username

--- a/acceptance-tests/helpers/brokers/env.go
+++ b/acceptance-tests/helpers/brokers/env.go
@@ -45,15 +45,3 @@ func (b Broker) env() []apps.EnvVar {
 
 	return append(result, b.envExtras...)
 }
-
-func (b Broker) releaseEnv() []apps.EnvVar {
-	return []apps.EnvVar{
-		{Name: "GSB_SERVICE_CSB_GOOGLE_POSTGRES_PLANS", Value: ""},
-	}
-}
-
-func (b Broker) latestEnv() []apps.EnvVar {
-	return []apps.EnvVar{
-		{Name: "GSB_SERVICE_CSB_GOOGLE_POSTGRES_PLANS", Value: `[{"name":"small","id":"85b27a04-8695-11ea-818a-274131861b81","description":"PostgreSQL v11, shared CPU, minumum 0.6GB ram, 10GB storage","display_name":"small","cores":0.6,"postgres_version":"POSTGRES_11","storage_gb":10},{"name":"medium","id":"b41ee300-8695-11ea-87df-cfcb8aecf3bc","description":"PostgreSQL v11, shared CPU, minumum 1.7GB ram, 20GB storage","display_name":"medium","cores":1.7,"postgres_version":"POSTGRES_11","storage_gb":20},{"name":"large","id":"2a57527e-b025-11ea-b643-bf3bcf6d055a","description":"PostgreSQL v11, minumum 8 cores, minumum 8GB ram, 50GB storage","display_name":"large","cores":8,"postgres_version":"POSTGRES_11","storage_gb":50}]`},
-	}
-}

--- a/acceptance-tests/helpers/brokers/update.go
+++ b/acceptance-tests/helpers/brokers/update.go
@@ -11,7 +11,6 @@ func (b *Broker) UpdateBroker(dir string) {
 		apps.WithDir(dir),
 	)
 
-	WithEnv(b.latestEnv()...)(b)
 	b.app.SetEnv(b.env()...)
 	b.app.Restart()
 

--- a/acceptance-tests/upgrade/update_and_upgrade_postgresql_test.go
+++ b/acceptance-tests/upgrade/update_and_upgrade_postgresql_test.go
@@ -17,7 +17,6 @@ var _ = Describe("UpgradePostgreSQLTest", Label("postgresql"), func() {
 			serviceBroker := brokers.Create(
 				brokers.WithPrefix("csb-postgresql"),
 				brokers.WithSourceDir(releasedBuildDir),
-				brokers.WithReleaseEnv(),
 			)
 			defer serviceBroker.Delete()
 

--- a/acceptance-tests/upgrade/update_and_upgrade_redis_test.go
+++ b/acceptance-tests/upgrade/update_and_upgrade_redis_test.go
@@ -17,7 +17,6 @@ var _ = Describe("UpgradeRedisTest", Label("redis"), func() {
 			serviceBroker := brokers.Create(
 				brokers.WithPrefix("csb-redis"),
 				brokers.WithSourceDir(releasedBuildDir),
-				brokers.WithReleaseEnv(),
 			)
 			defer serviceBroker.Delete()
 

--- a/acceptance-tests/upgrade/update_and_upgrade_storage_test.go
+++ b/acceptance-tests/upgrade/update_and_upgrade_storage_test.go
@@ -17,7 +17,6 @@ var _ = Describe("UpgradeStorageTest", Label("storage"), func() {
 			serviceBroker := brokers.Create(
 				brokers.WithPrefix("csb-storage"),
 				brokers.WithSourceDir(releasedBuildDir),
-				brokers.WithReleaseEnv(),
 			)
 			defer serviceBroker.Delete()
 


### PR DESCRIPTION
The upgrade tests test the upgrade from one version (the starting point)
to the very latest. Since we released this brokerpak recently, the
starting point has now moved and includes the change to make the
PostgreSQL plan an environment variable. As such we need to adjust the
tests to set this variable for the starting point as well as the end
point.

### Checklist:

* ~~[ ] Have you added Draft Release Notes in `docs/draft-release-notes.md`?~~
* [X] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

