### PR TITLE
feat: PostgreSQL backup can be configured

### DIFF
--- a/docs/draft-release-notes.md
+++ b/docs/draft-release-notes.md
@@ -1,7 +1,7 @@
 ## Release notes for next release:
 
 ### New feature:
-- PostgreSQL backups are enabled by default
+- PostgreSQL backups are enabled by default and can be configured via the new `backups_retain_number`, `backups_location`, `backups_start_time` and `backups_point_in_time_log_retain_days` properties
 
 ### Fix:
 

--- a/google-postgresql.yml
+++ b/google-postgresql.yml
@@ -122,6 +122,55 @@ provision:
     details: Assign a public ip to the database
     default: false
     prohibit_update: true
+  - field_name: backups_retain_number
+    details: Number of backups to retain; setting to zero disables backups
+    type: integer
+    default: 7
+    constraints:
+      maximum: 1000
+      minimum: 0
+  - field_name: backups_location
+    details: Location where backups are stored
+    type: string
+    default: "us"
+    enum:
+      us: us
+      eu: eu
+      asia: asia
+      asia-east1: asia-east1
+      asia-east2: asia-east2
+      asia-northeast1: asia-northeast1
+      asia-northeast2: asia-northeast2
+      asia-northeast3: asia-northeast3
+      asia-south1: asia-south1
+      asia-southeast1: asia-southeast1
+      australia-southeast1: australia-southeast1
+      europe-north1: europe-north1
+      europe-west1: europe-west1
+      europe-west2: europe-west2
+      europe-west3: europe-west3
+      europe-west4: europe-west4
+      europe-west6: europe-west6
+      northamerica-northeast1: northamerica-northeast1
+      southamerica-east1: southamerica-east1
+      us-central1: us-central1
+      us-east1: us-east1
+      us-east4: us-east4
+      us-west1: us-west1
+      us-west2: us-west2
+  - field_name: backups_start_time
+    details: Start time of the backup window in UTC
+    type: string
+    default: "07:00"
+    constraints:
+      pattern: "^[0-2][0-9]:[0-5][0-9]$"
+  - field_name: backups_point_in_time_log_retain_days
+    details: Number of days to retain point in time logs; setting to zero disables point in time logging; backups must be enabled
+    type: integer
+    default: 7
+    constraints:
+      maximum: 7
+      minimum: 0
   computed_inputs:
   - name: labels
     default: ${json.marshal(request.default_labels)}

--- a/integration-tests/postgres_test.go
+++ b/integration-tests/postgres_test.go
@@ -280,7 +280,7 @@ var _ = Describe("postgres", func() {
 			},
 			Entry("min backups_retain_number", "backups_retain_number", -1, "backups_retain_number: Must be greater than or equal to 0"),
 			Entry("max backups_retain_number", "backups_retain_number", 1001, "backups_retain_number: Must be less than or equal to 1000"),
-			Entry("invalid backups_location", "backups_location", "moon", `backups_location must be one of the following: \"asia\", \"eu\", \"us\"`),
+			Entry("invalid backups_location", "backups_location", "moon", `backups_location must be one of the following:`),
 			Entry("invalid backups_start_time", "backups_start_time", "34:91", `backups_start_time: Does not match pattern`),
 			Entry("min backups_point_in_time_log_retain_days", "backups_point_in_time_log_retain_days", -1, "backups_point_in_time_log_retain_days: Must be greater than or equal to 0"),
 			Entry("max backups_point_in_time_log_retain_days", "backups_point_in_time_log_retain_days", 8, "backups_point_in_time_log_retain_days: Must be less than or equal to 7"),

--- a/terraform/cloudsql/postgresql/provision/main.tf
+++ b/terraform/cloudsql/postgresql/provision/main.tf
@@ -24,13 +24,13 @@ resource "google_sql_database_instance" "instance" {
     }
 
     backup_configuration {
-      enabled = true
-      start_time = "17:00"
-      location = "us"
-      point_in_time_recovery_enabled = true
-      transaction_log_retention_days = 7
+      enabled = var.backups_retain_number != 0
+      start_time = var.backups_start_time
+      location = var.backups_location
+      point_in_time_recovery_enabled = var.backups_retain_number != 0 && var.backups_point_in_time_log_retain_days != 0
+      transaction_log_retention_days = var.backups_point_in_time_log_retain_days
       backup_retention_settings {
-        retained_backups = 7
+        retained_backups = var.backups_retain_number
       }
     }
   }

--- a/terraform/cloudsql/postgresql/provision/variables.tf
+++ b/terraform/cloudsql/postgresql/provision/variables.tf
@@ -10,6 +10,10 @@ variable "region" { type = string }
 variable "labels" { type = map(any) }
 variable "storage_gb" { type = number }
 variable "database_version" { type = string }
+variable "backups_retain_number" { type = number }
+variable "backups_location" { type = string }
+variable "backups_start_time" { type = string }
+variable "backups_point_in_time_log_retain_days" { type = number }
 
 variable "credentials" { type = string }
 variable "project" { type = string }


### PR DESCRIPTION
New properties: backups_retain_number, backups_location,
backups_start_time and backups_point_in_time_log_retain_days

[#181060141](https://www.pivotaltracker.com/story/show/181060141)

### Checklist:

* [X] Have you added Draft Release Notes in `docs/draft-release-notes.md`?
* [X] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

