### PR TITLE
feat: PostgreSQL scam password encryption

### DIFF
--- a/docs/draft-release-notes.md
+++ b/docs/draft-release-notes.md
@@ -2,6 +2,7 @@
 
 ### New feature:
 - PostgreSQL backups are enabled by default and can be configured via the new `backups_retain_number`, `backups_location`, `backups_start_time` and `backups_point_in_time_log_retain_days` properties
+- PostgreSQL password stored using `scram-sha-256` for additional security
 
 ### Fix:
 - minimum constraints on MySQL, PostreSQL, and Spanner storage_gb are now enforced

--- a/terraform/cloudsql/postgresql/provision/main.tf
+++ b/terraform/cloudsql/postgresql/provision/main.tf
@@ -23,6 +23,11 @@ resource "google_sql_database_instance" "instance" {
       }
     }
 
+    database_flags {
+      name = "password_encryption"
+      value = "scram-sha-256"
+    }
+
     backup_configuration {
       enabled = var.backups_retain_number != 0
       start_time = var.backups_start_time


### PR DESCRIPTION
Some older PostgreSQL clients don't support this setting, so we might
need to make it optional in future. But the improved security make it
worthwhile.

[#181742593](https://www.pivotaltracker.com/story/show/181742593)

### Checklist:

* [X] Have you added Draft Release Notes in `docs/draft-release-notes.md`?
* [X] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

