### PR TITLE
feat: PostgreSQL - allow update of properties

### DIFF
--- a/docs/draft-release-notes.md
+++ b/docs/draft-release-notes.md
@@ -3,6 +3,8 @@
 ### New feature:
 - PostgreSQL backups are enabled by default and can be configured via the new `backups_retain_number`, `backups_location`, `backups_start_time` and `backups_point_in_time_log_retain_days` properties
 - PostgreSQL password stored using `scram-sha-256` for additional security
+- PostgreSQL properties can now be updated: cores, storage_gb, credentials, authorized_network, authorized_network_id, authorized_networks_cidrs, public_ip
+
 
 ### Fix:
 - minimum constraints on MySQL, PostreSQL, and Spanner storage_gb are now enforced

--- a/google-postgresql.yml
+++ b/google-postgresql.yml
@@ -30,7 +30,6 @@ provision:
     required: true
     type: number
     details: Minimum number of cores for service instance.
-    prohibit_update: true
   - field_name: postgres_version
     required: true
     type: string
@@ -47,7 +46,6 @@ provision:
     type: number
     details: Size of storage volume for service instance.
     default: 10
-    prohibit_update: true
     constraints:
       maximum: 4096
       minimum: 10
@@ -59,7 +57,6 @@ provision:
     type: string
     details: GCP credentials
     default: ${config("gcp.credentials")}
-    prohibit_update: true
   - field_name: project
     type: string
     details: GCP project
@@ -106,22 +103,18 @@ provision:
     type: string
     details: The name of the Google Compute Engine network to which the instance is connected. If left unspecified, the network named 'default' will be used.
     default: default
-    prohibit_update: true
   - field_name: authorized_network_id
     type: string
-    details: The id of the Google Compute Engine network to which the instance is connected.
+    details: The id of the Google Compute Engine network to which the instance is connected. Overrides the 'authorized_network' property.
     default: ""
-    prohibit_update: true
   - field_name: authorized_networks_cidrs
     type: array
     details: CIDR notation IPv4 or IPv6 addresses that are allowed to access this instance.
     default: []
-    prohibit_update: true
   - field_name: public_ip
     type: boolean
     details: Assign a public ip to the database
     default: false
-    prohibit_update: true
   - field_name: backups_retain_number
     details: Number of backups to retain; setting to zero disables backups
     type: integer


### PR DESCRIPTION
The following properties do not result in the database being re-created
and are therefore now allowed to be modified:
- cores
- storage_gb
- credentials
- authorized_network
- authorized_network_id
- authorized_networks_cidrs
- public_ip

[#181058854](https://www.pivotaltracker.com/story/show/181058854)

### Checklist:

* [X] Have you added Draft Release Notes in `docs/draft-release-notes.md`?
* [X] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

