### PR TITLE
test: revert "unbind postgres before updating broker (#267)"

### DIFF
--- a/acceptance-tests/upgrade/update_and_upgrade_postgresql_test.go
+++ b/acceptance-tests/upgrade/update_and_upgrade_postgresql_test.go
@@ -53,15 +53,19 @@ var _ = Describe("UpgradePostgreSQLTest", Label("postgresql"), func() {
 			got := appTwo.GET("%s/%s", schema, keyOne)
 			Expect(got).To(Equal(valueOne))
 
-			By("deleting bindings created before the upgrade")
-			bindingOne.Unbind()
-			bindingTwo.Unbind()
-
 			By("pushing the development version of the broker")
 			serviceBroker.UpdateBroker(developmentBuildDir)
 
 			By("updating the instance plan")
 			serviceInstance.Update("-p", "medium")
+
+			By("checking previously written data still accessible")
+			got = appTwo.GET("%s/%s", schema, keyOne)
+			Expect(got).To(Equal(valueOne))
+
+			By("deleting bindings created before the upgrade")
+			bindingOne.Unbind()
+			bindingTwo.Unbind()
 
 			By("creating new bindings and testing they still work")
 			serviceInstance.Bind(appOne)


### PR DESCRIPTION
This reverts commit f410b1d51c1cdadabf5fd7c68eb6a969f1491a34.

We can do this because we now test with a later "old version" in the
upgrade tests, so this behaviour will now work.

[#181701604](https://www.pivotaltracker.com/story/show/181701604)

### Checklist:

* ~~[ ] Have you added Draft Release Notes in `docs/draft-release-notes.md`?~~
* [X] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

