### PR TITLE
chore: don't use ioutil package

### DIFF
--- a/acceptance-tests/apps/dataprocapp/app/run_job.go
+++ b/acceptance-tests/apps/dataprocapp/app/run_job.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"dataprocapp/credentials"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"regexp"
@@ -82,7 +82,7 @@ func handleRunJob(jobClient dataproc.JobControllerClient, creds credentials.Data
 
 		defer reader.Close()
 
-		body, err := ioutil.ReadAll(reader)
+		body, err := io.ReadAll(reader)
 		if err != nil {
 			fail(w, http.StatusFailedDependency, "could not read output from Dataproc Job: %v", err)
 			return


### PR DESCRIPTION
New code should not use ioutil as its on the path to deprecation

### Checklist:

* ~~[ ] Have you added Draft Release Notes in `docs/draft-release-notes.md`?~~
* [X] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

