### PR TITLE
test: PostgreSQL app should be able to use TLS 

### DIFF
--- a/acceptance-tests/apps/postgresqlapp/internal/app/app.go
+++ b/acceptance-tests/apps/postgresqlapp/internal/app/app.go
@@ -18,7 +18,10 @@ const (
 )
 
 func App(uri string) *mux.Router {
-	db := connect(uri)
+	db, err := connect(uri)
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	r := mux.NewRouter()
 	r.HandleFunc("/", aliveness).Methods(http.MethodHead, http.MethodGet)
@@ -35,24 +38,25 @@ func aliveness(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
-func connect(uri string) *sql.DB {
+func connect(uri string) (*sql.DB, error) {
 	db, err := sql.Open("pgx", uri)
+
 	if err != nil {
-		log.Fatalf("failed to connect to database: %s", err)
+		return nil, fmt.Errorf("%w: failed to connect to database", err)
 	}
 	db.SetMaxIdleConns(0)
 
 	_, err = db.Exec(fmt.Sprintf(`CREATE TABLE IF NOT EXISTS public.%s (%s VARCHAR(255) NOT NULL, %s VARCHAR(255) NOT NULL)`, tableName, keyColumn, valueColumn))
 	if err != nil {
-		log.Fatalf("Error creating table: %s", err)
+		return nil, fmt.Errorf("%w: error creating table", err)
 	}
 
 	_, err = db.Exec(fmt.Sprintf(`GRANT ALL ON TABLE public.%s TO PUBLIC`, tableName))
 	if err != nil {
-		log.Fatalf("Error granting table permissions: %s", err)
+		return nil, fmt.Errorf("%w: error granting table permissions", err)
 	}
 
-	return db
+	return db, nil
 }
 
 func fail(w http.ResponseWriter, code int, format string, a ...interface{}) {

--- a/acceptance-tests/apps/postgresqlapp/main.go
+++ b/acceptance-tests/apps/postgresqlapp/main.go
@@ -13,14 +13,14 @@ func main() {
 	log.Println("Starting.")
 
 	log.Println("Reading credentials.")
-	creds, err := credentials.Read()
+	uri, err := credentials.Read()
 	if err != nil {
 		panic(err)
 	}
 
 	port := port()
 	log.Printf("Listening on port: %s", port)
-	http.Handle("/", app.App(creds))
+	http.Handle("/", app.App(uri))
 	http.ListenAndServe(port, nil)
 }
 


### PR DESCRIPTION
This restores functionality from commit
https://github.com/cloudfoundry/csb-brokerpak-gcp/commit/f5cff4b75aba3f14d4550574222fa963b82c65e7 which had to be reverted. The
TLS functionality is not used yet. The plan is to enable that in a
future commit.

[#181059797](https://www.pivotaltracker.com/story/show/181059797)

### Checklist:

* ~~[ ] Have you added Draft Release Notes in `docs/draft-release-notes.md`?~~
* [X] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

