### PR TITLE
feat(PostgreSQL): connections should require TLS

### DIFF
--- a/docs/draft-release-notes.md
+++ b/docs/draft-release-notes.md
@@ -4,6 +4,7 @@
 - PostgreSQL backups are enabled by default and can be configured via the new `backups_retain_number`, `backups_location`, `backups_start_time` and `backups_point_in_time_log_retain_days` properties
 - PostgreSQL password stored using `scram-sha-256` for additional security
 - PostgreSQL properties can now be updated: cores, storage_gb, credentials, authorized_network, authorized_network_id, authorized_networks_cidrs, public_ip
+- PostgreSQL connections must be via TLS
 
 
 ### Fix:

--- a/google-postgresql.yml
+++ b/google-postgresql.yml
@@ -196,6 +196,15 @@ provision:
   - field_name: use_tls
     type: boolean
     details: Using TLS for connection
+  - field_name: sslcert
+    type: string
+    details: The client CA Cert to authenticate with SQL instance
+  - field_name: sslkey
+    type: string
+    details: The client CA Cert to authenticate with SQL instance
+  - field_name: sslrootcert
+    type: string
+    details: The CA Certificate used to connect to the SQL instance via TLS
 bind:
   plan_inputs: []
   user_inputs: []
@@ -219,6 +228,18 @@ bind:
   - name: use_tls
     type: boolean
     default: ${instance.details["use_tls"]}
+    overwrite: true
+  - name: sslcert
+    type: string
+    default: ${instance.details["sslcert"]}
+    overwrite: true
+  - name: sslkey
+    type: string
+    default: ${instance.details["sslkey"]}
+    overwrite: true
+  - name: sslrootcert
+    type: string
+    default: ${instance.details["sslrootcert"]}
     overwrite: true
   template_refs:
     provider: terraform/cloudsql/postgresql/bind/provider.tf

--- a/integration-tests/postgres_test.go
+++ b/integration-tests/postgres_test.go
@@ -214,12 +214,20 @@ var _ = Describe("postgres", func() {
 
 	Context("bind a service ", func() {
 		It("return the bind values from terraform output", func() {
+			const (
+				fakeSSLRoot    = "REAL_SSL_ROOT_CERT"
+				fakeClientCert = "REAL_SSL_CLIENT_CERT"
+				fakeClientKey  = "REAL_SSL_CLIENT_KEY"
+			)
 			mockTerraform.ReturnTFState([]testframework.TFStateValue{
 				{Name: "hostname", Type: "string", Value: "create.hostname.gcp.test"},
-				{Name: "use_tls", Type: "bool", Value: false},
+				{Name: "use_tls", Type: "bool", Value: true},
 				{Name: "username", Type: "string", Value: "create.test.username"},
 				{Name: "password", Type: "string", Value: "create.test.password"},
 				{Name: "name", Type: "string", Value: "create.test.instancename"},
+				{Name: "sslrootcert", Type: "string", Value: fakeSSLRoot},
+				{Name: "sslcert", Type: "string", Value: fakeClientCert},
+				{Name: "sslkey", Type: "string", Value: fakeClientKey},
 			})
 
 			instanceID, err := broker.Provision("csb-google-postgres", postgresAllOverridesPlan["name"].(string), nil)
@@ -235,13 +243,16 @@ var _ = Describe("postgres", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(bindResult).To(Equal(map[string]interface{}{
-				"username": "bind.test.username",
-				"hostname": "create.hostname.gcp.test",
-				"jdbcUrl":  "bind.test.jdbcUrl",
-				"name":     "create.test.instancename",
-				"password": "bind.test.password",
-				"uri":      "bind.test.uri",
-				"use_tls":  false,
+				"username":    "bind.test.username",
+				"hostname":    "create.hostname.gcp.test",
+				"jdbcUrl":     "bind.test.jdbcUrl",
+				"name":        "create.test.instancename",
+				"password":    "bind.test.password",
+				"uri":         "bind.test.uri",
+				"use_tls":     true,
+				"sslrootcert": fakeSSLRoot,
+				"sslcert":     fakeClientCert,
+				"sslkey":      fakeClientKey,
 			}))
 		})
 	})

--- a/manifest.yml
+++ b/manifest.yml
@@ -15,9 +15,9 @@ terraform_binaries:
 - name: terraform-provider-google
   version: 4.17.0
   source: https://github.com/terraform-providers/terraform-provider-google/archive/v4.17.0.zip
-- name: terraform-provider-random
-  version: 3.1.2
-  source: https://github.com/terraform-providers/terraform-provider-random/archive/v3.1.2.zip
+- name: terraform-provider-local
+  version: 2.2.2
+  source: https://github.com/terraform-providers/terraform-provider-local/archive/v2.2.2.zip
 - name: terraform-provider-mysql
   version: 1.9.0
   source: https://github.com/terraform-providers/terraform-provider-mysql/archive/v1.9.0.zip
@@ -26,6 +26,9 @@ terraform_binaries:
   provider: cyrilgdn/postgresql
   source: https://github.com/cyrilgdn/terraform-provider-postgresql/archive/v1.15.0.zip
   url_template: https://github.com/cyrilgdn/${name}/releases/download/v${version}/${name}_${version}_${os}_${arch}.zip
+- name: terraform-provider-random
+  version: 3.1.2
+  source: https://github.com/terraform-providers/terraform-provider-random/archive/v3.1.2.zip
 env_config_mapping:
   GOOGLE_CREDENTIALS: gcp.credentials
   GOOGLE_PROJECT: gcp.project

--- a/terraform/cloudsql/postgresql/bind/main.tf
+++ b/terraform/cloudsql/postgresql/bind/main.tf
@@ -20,3 +20,21 @@ resource "postgresql_role" "new_user" {
     var.admin_username
   ]
 }
+
+resource "local_file" "sslcert" {
+  content         = var.sslcert
+  filename        = "${path.module}/sslcert.pem"
+  file_permission = "0600"
+}
+
+resource "local_sensitive_file" "sslkey" {
+  content         = var.sslkey
+  filename        = "${path.module}/sslkey.pem"
+  file_permission = "0600"
+}
+
+resource "local_file" "sslrootcert" {
+  content         = var.sslrootcert
+  filename        = "${path.module}/sslrootcert.pem"
+  file_permission = "0600"
+}

--- a/terraform/cloudsql/postgresql/bind/outputs.tf
+++ b/terraform/cloudsql/postgresql/bind/outputs.tf
@@ -10,17 +10,19 @@ output "uri" {
     random_password.password.result,
     var.hostname,
     local.port,
-  var.db_name)
+    var.db_name,
+  )
 }
 output "port" { value = local.port }
 output "jdbcUrl" {
   sensitive = true
-  value = format("jdbc:%s://%s:%s/%s?user=%s\u0026password=%s\u0026verifyServerCertificate=true\u0026useSSL=%v\u0026requireSSL=false",
+  value = format("jdbc:%s://%s:%s/%s?user=%s\u0026password=%s\u0026verifyServerCertificate=true\u0026useSSL=%v\u0026requireSSL=true",
     "postgresql",
     var.hostname,
     local.port,
     var.db_name,
     random_string.username.result,
     random_password.password.result,
-  var.use_tls)
+    var.use_tls,
+  )
 }

--- a/terraform/cloudsql/postgresql/bind/provider.tf
+++ b/terraform/cloudsql/postgresql/bind/provider.tf
@@ -1,9 +1,14 @@
 provider "postgresql" {
-  host      = var.hostname
-  port      = local.port
-  username  = var.admin_username
-  password  = var.admin_password
-  superuser = false
-  database  = var.db_name
-  sslmode   = var.use_tls ? "require" : "disable"
+  host        = var.hostname
+  port        = local.port
+  username    = var.admin_username
+  password    = var.admin_password
+  superuser   = false
+  database    = var.db_name
+  sslmode     = "verify-ca"
+  sslrootcert = local_file.sslrootcert.filename
+  clientcert {
+    cert = local_file.sslcert.filename
+    key  = local_sensitive_file.sslkey.filename
+  }
 }

--- a/terraform/cloudsql/postgresql/bind/variables.tf
+++ b/terraform/cloudsql/postgresql/bind/variables.tf
@@ -2,7 +2,10 @@ variable "db_name" { type = string }
 variable "hostname" { type = string }
 variable "admin_username" { type = string }
 variable "admin_password" { type = string }
-variable "use_tls" { type = bool }
+#variable "use_tls" { type = bool }
+variable "sslcert" { type = string }
+variable "sslkey" { type = string }
+variable "sslrootcert" { type = string }
 
 locals {
   port = 5432

--- a/terraform/cloudsql/postgresql/bind/versions.tf
+++ b/terraform/cloudsql/postgresql/bind/versions.tf
@@ -9,5 +9,10 @@ terraform {
       source  = "hashicorp/random"
       version = ">=3.1.0"
     }
+
+    local = {
+      source  = "hashicorp/local"
+      version = ">=2.2.2"
+    }
   }
 }

--- a/terraform/cloudsql/postgresql/provision/outputs.tf
+++ b/terraform/cloudsql/postgresql/provision/outputs.tf
@@ -6,4 +6,11 @@ output "password" {
   sensitive = true
   value     = postgresql_role.createrole_user.password
 }
-output "use_tls" { value = false }
+output "use_tls" { value = true }
+
+output "sslcert" { value = google_sql_ssl_cert.client_cert.cert }
+output "sslkey" {
+  value     = google_sql_ssl_cert.client_cert.private_key
+  sensitive = true
+}
+output "sslrootcert" { value = google_sql_database_instance.instance.server_ca_cert.0.cert }

--- a/terraform/cloudsql/postgresql/provision/provider.tf
+++ b/terraform/cloudsql/postgresql/provision/provider.tf
@@ -4,11 +4,16 @@ provider "google" {
 }
 
 provider "postgresql" {
-  host      = google_sql_database_instance.instance.first_ip_address
-  port      = 5432
-  username  = google_sql_user.admin_user.name
-  password  = google_sql_user.admin_user.password
-  superuser = false
-  database  = google_sql_database.database.name
-  sslmode   = "disable"
+  host        = google_sql_database_instance.instance.first_ip_address
+  port        = 5432
+  username    = google_sql_user.admin_user.name
+  password    = google_sql_user.admin_user.password
+  superuser   = false
+  database    = google_sql_database.database.name
+  sslmode     = "verify-ca"
+  sslrootcert = local_file.sslrootcert.filename
+  clientcert {
+    cert = local_file.sslcert.filename
+    key  = local_sensitive_file.sslkey.filename
+  }
 }

--- a/terraform/cloudsql/postgresql/provision/versions.tf
+++ b/terraform/cloudsql/postgresql/provision/versions.tf
@@ -5,9 +5,19 @@ terraform {
       version = ">=4.8.0"
     }
 
+    random = {
+      source  = "hashicorp/random"
+      version = ">=3.1.0"
+    }
+
     postgresql = {
       source  = "cyrilgdn/postgresql"
       version = ">=1.15.0"
+    }
+
+    local = {
+      source  = "hashicorp/local"
+      version = ">=2.2.2"
     }
   }
 }


### PR DESCRIPTION
This restores the functionality from f5cff4b which was previously reverted.

[#181059797](https://www.pivotaltracker.com/story/show/181059797)

### Checklist:

* [X] Have you added Draft Release Notes in `docs/draft-release-notes.md`?
* [X] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

