### PR TITLE
build: revert "chore(PostgreSQL): use strong passwords for management…

### DIFF
--- a/terraform/cloudsql/postgresql/provision/main.tf
+++ b/terraform/cloudsql/postgresql/provision/main.tf
@@ -54,7 +54,7 @@ resource "random_string" "username" {
 }
 
 resource "random_password" "password" {
-  length           = 64
+  length           = 16
   special          = true
   override_special = "_@"
 }
@@ -71,7 +71,7 @@ resource "random_string" "createrole_username" {
   special = false
 }
 resource "random_password" "createrole_password" {
-  length           = 64
+  length           = 16
   special          = true
   override_special = "_@"
 }


### PR DESCRIPTION
… accounts (#297)"

This caused the upgrade test to fail because:
- the password is marked invalid as it needs to be re-genereated
- the PosgreSQL provider is configured with the password that's now marked
invalid
- the PosgreSQL provider cannot connect during the refresh phase at the
start of `terraform apply`

This reverts commit 961f9a9da2cb1d7359b40486a13bd44fd3431978.

### Checklist:

* ~~[ ] Have you added Draft Release Notes in `docs/draft-release-notes.md`?~~
* [X] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

