### PR TITLE
feat!: change PostgreSQL GUIDs to prevent upgrade

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ PAK_CACHE=/tmp/.pak-cache
 SECURITY_USER_NAME := $(or $(SECURITY_USER_NAME), aws-broker)
 SECURITY_USER_PASSWORD := $(or $(SECURITY_USER_PASSWORD), aws-broker-pw)
 GSB_COMPATIBILITY_ENABLE_BETA_SERVICES :=true
-export GSB_SERVICE_CSB_GOOGLE_POSTGRES_PLANS = [{"name":"small","id":"85b27a04-8695-11ea-818a-274131861b81","description":"PostgreSQL with default version, shared CPU, minimum 0.6GB ram, 10GB storage","display_name":"small","tier":"db-f1-micro","storage_gb":10},{"name":"medium","id":"b41ee300-8695-11ea-87df-cfcb8aecf3bc","description":"PostgreSQL with default version, shared CPU, minimum 1.7GB ram, 20GB storage","display_name":"medium","tier":"db-g1-small","storage_gb":20},{"name":"large","id":"2a57527e-b025-11ea-b643-bf3bcf6d055a","description":"PostgreSQL with default version, minimum 8 cores, minimum 8GB ram, 50GB storage","display_name":"large","tier":"db-n1-standard-8","storage_gb":50}]
+export GSB_SERVICE_CSB_GOOGLE_POSTGRES_PLANS = [{"name":"small","id":"5b45de36-cb90-11ec-a755-77f8be95a49d","description":"PostgreSQL with default version, shared CPU, minimum 0.6GB ram, 10GB storage","display_name":"small","tier":"db-f1-micro","storage_gb":10},{"name":"medium","id":"a3359fa6-cb90-11ec-bcb6-cb68544eda78","description":"PostgreSQL with default version, shared CPU, minimum 1.7GB ram, 20GB storage","display_name":"medium","tier":"db-g1-small","storage_gb":20},{"name":"large","id":"cd95c5b4-cb90-11ec-a5da-df87b7fb7426","description":"PostgreSQL with default version, minimum 8 cores, minimum 8GB ram, 50GB storage","display_name":"large","tier":"db-n1-standard-8","storage_gb":50}]
 GSB_PROVISION_DEFAULTS := $(or $(GSB_PROVISION_DEFAULTS), {"authorized_network": "$(GCP_PAS_NETWORK)"})
 
 ifeq ($(GO_OK), 0) # use local go binary

--- a/acceptance-tests/helpers/brokers/env.go
+++ b/acceptance-tests/helpers/brokers/env.go
@@ -40,7 +40,7 @@ func (b Broker) env() []apps.EnvVar {
 		apps.EnvVar{Name: "ENCRYPTION_ENABLED", Value: true},
 		apps.EnvVar{Name: "ENCRYPTION_PASSWORDS", Value: b.secrets},
 		apps.EnvVar{Name: "BROKERPAK_UPDATES_ENABLED", Value: true},
-		apps.EnvVar{Name: "GSB_SERVICE_CSB_GOOGLE_POSTGRES_PLANS", Value: `[{"name":"small","id":"85b27a04-8695-11ea-818a-274131861b81","description":"PostgreSQL v11, shared CPU, minimum 0.6GB ram, 10GB storage","display_name":"small","cores":0.6,"postgres_version":"POSTGRES_11","storage_gb":10},{"name":"medium","id":"b41ee300-8695-11ea-87df-cfcb8aecf3bc","description":"PostgreSQL v11, shared CPU, minimum 1.7GB ram, 20GB storage","display_name":"medium","cores":1.7,"postgres_version":"POSTGRES_11","storage_gb":20},{"name":"large","id":"2a57527e-b025-11ea-b643-bf3bcf6d055a","description":"PostgreSQL v11, minimum 8 cores, minimum 8GB ram, 50GB storage","display_name":"large","cores":8,"postgres_version":"POSTGRES_11","storage_gb":50}]`},
+		apps.EnvVar{Name: "GSB_SERVICE_CSB_GOOGLE_POSTGRES_PLANS", Value: `[{"name":"small","id":"5b45de36-cb90-11ec-a755-77f8be95a49d","description":"PostgreSQL v11, shared CPU, minimum 0.6GB ram, 10GB storage","display_name":"small","cores":0.6,"postgres_version":"POSTGRES_11","storage_gb":10},{"name":"medium","id":"a3359fa6-cb90-11ec-bcb6-cb68544eda78","description":"PostgreSQL v11, shared CPU, minimum 1.7GB ram, 20GB storage","display_name":"medium","cores":1.7,"postgres_version":"POSTGRES_11","storage_gb":20},{"name":"large","id":"cd95c5b4-cb90-11ec-a5da-df87b7fb7426","description":"PostgreSQL v11, minimum 8 cores, minimum 8GB ram, 50GB storage","display_name":"large","cores":8,"postgres_version":"POSTGRES_11","storage_gb":50}]`},
 	)
 
 	return append(result, b.envExtras...)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -123,7 +123,7 @@ service:
     plans: '[
       {
         "name":"small",
-        "id":"85b27a04-8695-11ea-818a-274131861b81",
+        "id":"5b45de36-cb90-11ec-a755-77f8be95a49d",
         "description":"PostgreSQL with default version, shared CPU, minimum 0.6GB ram, 10GB storage",
         "display_name":"small",
         "tier":"db-f1-micro",

--- a/docs/draft-release-notes.md
+++ b/docs/draft-release-notes.md
@@ -1,6 +1,9 @@
 ## Release notes for next release:
 
 ### New feature:
+- BREAKING: Due to new features in the PostgreSQL service offering, it is not possible to upgrade from
+  a previous (Beta) version to this version. You should either delete existing PostgreSQL instances before upgrade, or
+  run "cf purge-service-instance" on them to remove them from CloudFoundry management.
 - PostgreSQL backups are enabled by default and can be configured via the new `backups_retain_number`, `backups_location`, `backups_start_time` and `backups_point_in_time_log_retain_days` properties
 - PostgreSQL password stored using `scram-sha-256` for additional security
 - PostgreSQL properties can now be updated: cores, storage_gb, credentials, authorized_network, authorized_network_id, authorized_networks_cidrs, public_ip

--- a/google-postgresql.yml
+++ b/google-postgresql.yml
@@ -14,7 +14,7 @@
 ---
 version: 1
 name: csb-google-postgres
-id: e4ac5b1c-8693-11ea-8977-1f3cd95a07dd
+id: 40501b82-cb90-11ec-b1c2-e3a703778055
 description: Beta - PostgreSQL is a fully managed service for the
   Google Cloud Platform.
 display_name: Google Cloud PostgreSQL (Beta)
@@ -284,7 +284,7 @@ bind:
 examples:
 - name: small configuration
   description: Create a small postgres instance
-  plan_id: 85b27a04-8695-11ea-818a-274131861b81
+  plan_id: 5b45de36-cb90-11ec-a755-77f8be95a49d
   provision_params: { "authorized_networks_cidrs": ["0.0.0.0/0"], "public_ip": true}
   bind_params: {}
   bind_can_fail: true

--- a/scripts/push-broker.sh
+++ b/scripts/push-broker.sh
@@ -99,7 +99,7 @@ if [[ ${GSB_DEBUG} ]]; then
 fi
 
 if [[ -z "$GSB_SERVICE_CSB_GOOGLE_POSTGRES_PLANS" ]]; then
-  GSB_SERVICE_CSB_GOOGLE_POSTGRES_PLANS='[{"name":"small","id":"85b27a04-8695-11ea-818a-274131861b81","description":"PostgreSQL with default version, shared CPU, minimum 0.6GB ram, 10GB storage","display_name":"small","cores":0.6,"storage_gb":10},{"name":"medium","id":"b41ee300-8695-11ea-87df-cfcb8aecf3bc","description":"PostgreSQL with default version, shared CPU, minimum 1.7GB ram, 20GB storage","display_name":"medium","cores":1.7,"storage_gb":20},{"name":"large","id":"2a57527e-b025-11ea-b643-bf3bcf6d055a","description":"PostgreSQL with default version, minimum 8 cores, minimum 8GB ram, 50GB storage","display_name":"large","cores":8,"storage_gb":50}]'
+  GSB_SERVICE_CSB_GOOGLE_POSTGRES_PLANS='[{"name":"small","id":"5b45de36-cb90-11ec-a755-77f8be95a49d","description":"PostgreSQL with default version, shared CPU, minimum 0.6GB ram, 10GB storage","display_name":"small","cores":0.6,"storage_gb":10},{"name":"medium","id":"a3359fa6-cb90-11ec-bcb6-cb68544eda78","description":"PostgreSQL with default version, shared CPU, minimum 1.7GB ram, 20GB storage","display_name":"medium","cores":1.7,"storage_gb":20},{"name":"large","id":"cd95c5b4-cb90-11ec-a5da-df87b7fb7426","description":"PostgreSQL with default version, minimum 8 cores, minimum 8GB ram, 50GB storage","display_name":"large","cores":8,"storage_gb":50}]'
 fi
 cf set-env "${APP_NAME}" GSB_SERVICE_CSB_GOOGLE_POSTGRES_PLANS "${GSB_SERVICE_CSB_GOOGLE_POSTGRES_PLANS}"
 


### PR DESCRIPTION
Upgrading from previous (beta) versions will not be possible due to the
number of changes. So the service offering GUID and plan GUIDs have been
changed to avoid accidental upgrades. Any attempt to upgrade will result
in a CloudFoundry error.

[#182060896](https://www.pivotaltracker.com/story/show/182060896)

### Checklist:

* [X] Have you added Draft Release Notes in `docs/draft-release-notes.md`?
* [X] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

