### PR TITLE
chore: improve Go version check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,8 @@ help: ## list Makefile targets
 
 ###### Setup ##################################################################
 IAAS=gcp
+GO-VERSION = 1.18.1
+GO-VER = go$(GO-VERSION)
 CSB_VERSION := $(or $(CSB_VERSION), $(shell grep 'github.com/cloudfoundry/cloud-service-broker' go.mod | grep -v replace | awk '{print $$NF}' | sed -e 's/v//'))
 CSB_RELEASE_VERSION := $(CSB_VERSION)
 
@@ -73,8 +75,17 @@ endif
 
 ###### Targets ################################################################
 
+.PHONY: deps-go-binary
+deps-go-binary:
+ifeq ($(SKIP_GO_VERSION_CHECK),)
+	@@if [ "$$($(GO) version | awk '{print $$3}')" != "${GO-VER}" ]; then \
+		echo "Go version does not match: expected: ${GO-VER}, got $$($(GO) version | awk '{print $$3}')"; \
+		exit 1; \
+	fi
+endif
+
 .PHONY: build
-build: $(IAAS)-services-*.brokerpak ## build brokerpak
+build: deps-go-binary $(IAAS)-services-*.brokerpak ## build brokerpak
 
 $(IAAS)-services-*.brokerpak: *.yml terraform/*/*/*.tf ./providers/terraform-provider-csbpg/cloudfoundry.org/cloud-service-broker/csbpg | $(PAK_CACHE)
 	$(RUN_CSB) pak build

--- a/providers/terraform-provider-csbpg/Makefile
+++ b/providers/terraform-provider-csbpg/Makefile
@@ -1,6 +1,7 @@
 .DEFAULT_GOAL = help
 
 GO-VERSION = 1.18.1
+GO-VER = go$(GO-VERSION)
 GO_OK :=  $(or $(USE_GO_CONTAINERS), $(shell which go 1>/dev/null 2>/dev/null; echo $$?))
 DOCKER_OK := $(shell which docker 1>/dev/null 2>/dev/null; echo $$?)
 ifeq ($(GO_OK), 0)
@@ -15,7 +16,7 @@ endif
 help: ## list Makefile targets
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
-build: cloudfoundry.org ## build the provider
+build: deps-go-binary cloudfoundry.org ## build the provider
 
 cloudfoundry.org: *.go */*.go
 	mkdir -p cloudfoundry.org/cloud-service-broker/csbpg/1.0.0/linux_amd64
@@ -36,3 +37,12 @@ test: ## run the tests
 .PHONY: init
 init: build ## perform terraform init with this provider
 	terraform init --plugin-dir .
+
+.PHONY: deps-go-binary
+deps-go-binary:
+ifeq ($(SKIP_GO_VERSION_CHECK),)
+	@@if [ "$$($(GO) version | awk '{print $$3}')" != "${GO-VER}" ]; then \
+		echo "Go version does not match: expected: ${GO-VER}, got $$($(GO) version | awk '{print $$3}')"; \
+		exit 1; \
+	fi
+endif


### PR DESCRIPTION
- new check only prints when there is an error
- new check does not allow substring matches

[#181960182](https://www.pivotaltracker.com/story/show/181960182)

### Checklist:

* [ ] Have you added Draft Release Notes in `docs/draft-release-notes.md`?
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

