### PR TITLE
fix: add lifecycle.prevent_destroy to PostgreSQL

### DIFF
--- a/docs/draft-release-notes.md
+++ b/docs/draft-release-notes.md
@@ -1,3 +1,6 @@
 ## Release notes for next release:
 
+## Fixes:
+- adds lifecycle.prevent_destroy to PostgreSQL to provide extra layer of protection against data loss
+
 

--- a/terraform/cloudsql/postgresql/provision/main.tf
+++ b/terraform/cloudsql/postgresql/provision/main.tf
@@ -41,11 +41,19 @@ resource "google_sql_database_instance" "instance" {
   }
 
   deletion_protection = false
+
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 resource "google_sql_database" "database" {
   name     = var.db_name
   instance = google_sql_database_instance.instance.name
+
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 resource "random_string" "username" {


### PR DESCRIPTION
When the "prevent_destroy" property is true, Terraform will not
allow the resource to be deleted. This provides extra protection
during a service update as sometimes changing properties (e.g
the database name) can cause the database to be deleted and re-created.
We think we have blocked changing all the destructive properties,
but this adds an extra layer of protection against data loss in
case of error.

[#181445529](https://www.pivotaltracker.com/story/show/181445529)

### Checklist:

* [x] Have you added Draft Release Notes in `docs/draft-release-notes.md`?
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

