### PR TITLE
test: fix test setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,14 +111,14 @@ run-examples: ## run examples against CSB on localhost (run "make run" to start 
 	$(RUN_CSB) client run-examples --service-name="$(service_name)" --example-name="$(example_name)" -j $(PARALLEL_JOB_COUNT)
 
 .PHONY: test ## run the tests
-test: latest-csb lint provider-tests run-integration-tests
+test: lint provider-tests run-integration-tests
 
 .PHONY: run-integration-tests
 run-integration-tests: latest-csb ## run integration tests for this brokerpak
 	cd ./integration-tests && go run github.com/onsi/ginkgo/v2/ginkgo -r .
 
 .PHONY: provider-tests
-provider-tests:
+provider-tests: latest-csb
 	cd providers/terraform-provider-csbpg; $(MAKE) test
 
 .PHONY: info

--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,7 @@ run-examples: ## run examples against CSB on localhost (run "make run" to start 
 	$(RUN_CSB) client run-examples --service-name="$(service_name)" --example-name="$(example_name)" -j $(PARALLEL_JOB_COUNT)
 
 .PHONY: test ## run the tests
-test: lint provider-tests run-integration-tests
+test: latest-csb lint provider-tests run-integration-tests
 
 .PHONY: run-integration-tests
 run-integration-tests: latest-csb ## run integration tests for this brokerpak

--- a/integration-tests/mysql_test.go
+++ b/integration-tests/mysql_test.go
@@ -163,6 +163,7 @@ var _ = Describe("Mysql", func() {
 		var instanceID string
 
 		BeforeEach(func() {
+			mockTerraform.SetTFState([]testframework.TFStateValue{})
 			instanceID, _ = broker.Provision("csb-google-mysql", customMySQLPlan["name"].(string), nil)
 
 			Expect(mockTerraform.FirstTerraformInvocationVars()).To(

--- a/integration-tests/postgres_test.go
+++ b/integration-tests/postgres_test.go
@@ -61,6 +61,7 @@ var _ = Describe("postgres", func() {
 		var instanceGUID string
 
 		BeforeEach(func() {
+			mockTerraform.SetTFState([]testframework.TFStateValue{})
 			instanceGUID, _ = broker.Provision("csb-google-postgres", postgresNoOverridesPlan["name"].(string), map[string]any{"tier": "db-f1-micro"})
 
 			Expect(mockTerraform.FirstTerraformInvocationVars()).To(HaveKeyWithValue("tier", "db-f1-micro"))

--- a/integration-tests/redis_test.go
+++ b/integration-tests/redis_test.go
@@ -156,6 +156,7 @@ var _ = Describe("Redis", func() {
 		var instanceID string
 
 		BeforeEach(func() {
+			mockTerraform.SetTFState([]testframework.TFStateValue{})
 			instanceID, _ = broker.Provision(redisServiceName, customRedisPlan["name"].(string), nil)
 
 			Expect(mockTerraform.FirstTerraformInvocationVars()).To(


### PR DESCRIPTION
- a recent change made to the broker core results in a check of
  the terraform state before performing an update. This change ensures
  that the state gets initialised before the provision step.

[#182208889](https://www.pivotaltracker.com/story/show/182208889)

### Checklist:

* [ ] Have you added Draft Release Notes in `docs/draft-release-notes.md`?
* [ ] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

