### PR TITLE
test: update spacing in error message to match current message

### DIFF
--- a/acceptance-tests/errormessages_test.go
+++ b/acceptance-tests/errormessages_test.go
@@ -39,7 +39,7 @@ var _ = Describe("Error Messages", Label("errormessages"), func() {
 			}, 10*time.Minute, 10*time.Second).Should(MatchRegexp(`status:\s+create failed`))
 
 			stdout, _ := cf.Run("service", name)
-			Expect(stdout).To(MatchRegexp(`message:\s+provision failed: Error: googleapi: Error 400: Unknown project id: not-real-project, invalid  with google_storage_bucket.bucket,  on main.tf line 1, in resource "google_storage_bucket" "bucket":   1: resource "google_storage_bucket" "bucket"`))
+			Expect(stdout).To(MatchRegexp(`message:\s+provision failed: Error: googleapi: Error 400: Unknown project id: not-real-project, invalid with google_storage_bucket.bucket, on main.tf line 1, in resource "google_storage_bucket" "bucket": 1: resource "google_storage_bucket" "bucket"`))
 		})
 	})
 })


### PR DESCRIPTION
This is due to a fix in the CSB which removes duplicate spaces
https://github.com/cloudfoundry/cloud-service-broker/commit/36c31b9b21e4e72a8b67ce78e24659558fdb5acf

### Checklist:

* ~~[ ] Have you added Draft Release Notes in `docs/draft-release-notes.md`?~~
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

