### PR TITLE
fix: Change the default name to not rely on timestamp

### DIFF
--- a/acceptance-tests/upgrade/update_and_upgrade_dataproc_test.go
+++ b/acceptance-tests/upgrade/update_and_upgrade_dataproc_test.go
@@ -6,6 +6,7 @@ import (
 	"csbbrokerpakgcp/acceptance-tests/helpers/matchers"
 	"csbbrokerpakgcp/acceptance-tests/helpers/random"
 	"csbbrokerpakgcp/acceptance-tests/helpers/services"
+	"fmt"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -23,7 +24,12 @@ var _ = Describe("UpgradeDataprocTest", Label("dataproc"), func() {
 			defer serviceBroker.Delete()
 
 			By("creating a service instance")
-			serviceInstance := services.CreateInstance("csb-google-dataproc", "standard", services.WithBroker(serviceBroker))
+			serviceInstance := services.CreateInstance(
+				"csb-google-dataproc",
+				"standard",
+				services.WithBroker(serviceBroker),
+				services.WithParameters(map[string]interface{}{"name": fmt.Sprintf("csb-dataproc-%s", serviceBroker.Name)}),
+			)
 			defer serviceInstance.Delete()
 
 			By("pushing the unstarted app")

--- a/acceptance-tests/upgrade/update_and_upgrade_redis_test.go
+++ b/acceptance-tests/upgrade/update_and_upgrade_redis_test.go
@@ -9,6 +9,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/pborman/uuid"
 )
 
 var _ = Describe("UpgradeRedisTest", Label("redis"), func() {
@@ -28,7 +29,7 @@ var _ = Describe("UpgradeRedisTest", Label("redis"), func() {
 				"csb-google-redis",
 				"basic",
 				services.WithBroker(serviceBroker),
-				services.WithParameters(map[string]interface{}{"instance_id": fmt.Sprintf("csb-redis-%s", serviceBroker.Name)}),
+				services.WithParameters(map[string]interface{}{"instance_id": fmt.Sprintf("test-%s", uuid.NewUUID())}),
 			)
 			defer serviceInstance.Delete()
 

--- a/acceptance-tests/upgrade/update_and_upgrade_redis_test.go
+++ b/acceptance-tests/upgrade/update_and_upgrade_redis_test.go
@@ -59,6 +59,12 @@ var _ = Describe("UpgradeRedisTest", Label("redis"), func() {
 			By("getting the value using the second app")
 			Expect(appTwo.GET(key1)).To(Equal(value1))
 
+			By("updating the instance plan")
+			serviceInstance.Update("-c", `{"memory_size_gb":6}`)
+
+			By("getting the value using the second app")
+			Expect(appTwo.GET(key1)).To(Equal(value1))
+
 			By("deleting bindings created before the upgrade")
 			bindingOne.Unbind()
 			bindingTwo.Unbind()

--- a/acceptance-tests/upgrade/update_and_upgrade_redis_test.go
+++ b/acceptance-tests/upgrade/update_and_upgrade_redis_test.go
@@ -5,6 +5,7 @@ import (
 	"csbbrokerpakgcp/acceptance-tests/helpers/brokers"
 	"csbbrokerpakgcp/acceptance-tests/helpers/random"
 	"csbbrokerpakgcp/acceptance-tests/helpers/services"
+	"fmt"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -22,10 +23,12 @@ var _ = Describe("UpgradeRedisTest", Label("redis"), func() {
 			defer serviceBroker.Delete()
 
 			By("creating a service")
+
 			serviceInstance := services.CreateInstance(
 				"csb-google-redis",
 				"basic",
 				services.WithBroker(serviceBroker),
+				services.WithParameters(map[string]interface{}{"instance_id": fmt.Sprintf("csb-redis-%s", serviceBroker.Name)}),
 			)
 			defer serviceInstance.Delete()
 

--- a/acceptance-tests/upgrade/update_and_upgrade_spanner_test.go
+++ b/acceptance-tests/upgrade/update_and_upgrade_spanner_test.go
@@ -56,8 +56,8 @@ var _ = Describe("UpgradeSpannerTest", Label("spanner"), func() {
 			By("checking previously written data still accessible")
 			Expect(appOne.GET(key)).To(Equal(value))
 
-			By("updating the instance plan")
-			serviceInstance.Update("-p", "medium")
+			By("updating the instance config")
+			serviceInstance.Update("-c", `{"config":"us-west1"}`)
 
 			By("checking previously written data still accessible")
 			Expect(appOne.GET(key)).To(Equal(value))

--- a/docs/draft-release-notes.md
+++ b/docs/draft-release-notes.md
@@ -13,5 +13,5 @@
 - Adds lifecycle.prevent_destroy to all data services to provide extra layer of protection against data loss.
 - Adds prohibit_update property to avoid updating region in BigQuery and Storage services because it can result in the
   recreation of the service instance and lost data.
-- Redis and Dataproc names in the GCP console now rely on the instance request ID. It was previously relying on a
+- Redis and Dataproc names in the GCP console now rely on the request instance ID. It was previously relying on a
   timestamp that was causing updates to destroy the instance.

--- a/docs/draft-release-notes.md
+++ b/docs/draft-release-notes.md
@@ -2,10 +2,16 @@
 
 ## Features:
 
-- Service instances can be upgraded to latest TF v 1.2.3
+- Service instances can be upgraded to latest TF v 1.2.3. Notes: If you have Redis or Dataproc instances created without
+  defining `instance_id` for Redis or `name` for Dataproc you have to update those instances before installing this
+  version. For Redis instances
+  run `cf update-service your-redis-si -c '{"instance_id":"<current-name-from-GCP-console>"}'`. For Dataproc instances
+  run `cf update-service your-dataproc-si -c '{"name":"<current-name-from-GCP-console>"}'`.
 
 ## Fixes:
 
-- Adds lifecycle.prevent_destroy to all data services to provide extra layer of protection against data loss
+- Adds lifecycle.prevent_destroy to all data services to provide extra layer of protection against data loss.
 - Adds prohibit_update property to avoid updating region in BigQuery and Storage services because it can result in the
   recreation of the service instance and lost data.
+- Redis and Dataproc names in the GCP console now rely on the instance request ID. It was previously relying on a
+  timestamp that was causing updates to destroy the instance.

--- a/google-dataproc.yml
+++ b/google-dataproc.yml
@@ -44,7 +44,7 @@ provision:
   - field_name: name
     type: string
     details: The name of the cluster.
-    default: pcf-sb-${counter.next()}-${time.nano()}
+    default: csb-dataproc-${request.instance_id}
     constraints:
       maxLength: 222
       minLength: 3

--- a/google-redis.yml
+++ b/google-redis.yml
@@ -55,10 +55,10 @@ provision:
   - field_name: instance_id
     type: string
     details: Permanent identifier for your instance
-    default: csb-redis-${request.instance_id}
+    default: csb-${request.instance_id}
     constraints:
-      maxLength: 30
-      minLength: 6
+      maxLength: 40
+      minLength: 1
       pattern: ^[a-z][a-z0-9-]+$
   - field_name: display_name
     type: string

--- a/google-redis.yml
+++ b/google-redis.yml
@@ -55,7 +55,7 @@ provision:
   - field_name: instance_id
     type: string
     details: Permanent identifier for your instance
-    default: pcf-sb-${counter.next()}-${time.nano()}
+    default: csb-redis-${request.instance_id}
     constraints:
       maxLength: 30
       minLength: 6

--- a/google-redis.yml
+++ b/google-redis.yml
@@ -58,7 +58,7 @@ provision:
     default: csb-${request.instance_id}
     constraints:
       maxLength: 40
-      minLength: 1
+      minLength: 6
       pattern: ^[a-z][a-z0-9-]+$
   - field_name: display_name
     type: string

--- a/integration-tests/redis_test.go
+++ b/integration-tests/redis_test.go
@@ -72,8 +72,8 @@ var _ = Describe("Redis", func() {
 					HaveKeyWithValue("authorized_network", "default"),
 					HaveKeyWithValue("authorized_network_id", ""),
 					HaveKeyWithValue("reserved_ip_range", ""),
-					HaveKeyWithValue("display_name", ContainSubstring("pcf-sb-")),
-					HaveKeyWithValue("instance_id", ContainSubstring("pcf-sb-")),
+					HaveKeyWithValue("display_name", ContainSubstring("csb-")),
+					HaveKeyWithValue("instance_id", ContainSubstring("csb-")),
 					HaveKeyWithValue("labels", HaveKeyWithValue("pcf-instance-id", instanceID)),
 				),
 			)
@@ -131,9 +131,9 @@ var _ = Describe("Redis", func() {
 				"memory_size_gb: Must be greater than or equal to 1",
 			),
 			Entry(
-				"instance_id maximum length is 30 characters",
-				map[string]any{"instance_id": stringOfLen(31)},
-				"instance_id: String length must be less than or equal to 30",
+				"instance_id maximum length is 40 characters",
+				map[string]any{"instance_id": stringOfLen(41)},
+				"instance_id: String length must be less than or equal to 40",
 			),
 			Entry(
 				"instance_id minimum length is 6 characters",
@@ -168,7 +168,7 @@ var _ = Describe("Redis", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(mockTerraform.FirstTerraformInvocationVars()).To(
 				SatisfyAll(
-					HaveKeyWithValue("instance_id", ContainSubstring("pcf-sb-")),
+					HaveKeyWithValue("instance_id", ContainSubstring("csb-")),
 					HaveKeyWithValue("labels", HaveKeyWithValue("pcf-instance-id", instanceID)),
 					HaveKeyWithValue("service_tier", "TIER_UNSPECIFIED"),
 				),


### PR DESCRIPTION
Redis instance_id and dataproc name default values were relying on timestamp. That causes every subsequent operation (update/upgrade) to regenerate the variable and that triggers tf to destroy the original instance.

[#182570764](https://www.pivotaltracker.com/story/show/182570764)

Co-Authored-By: Marcela Campo <20945140+pivotal-marcela-campo@users.noreply.github.com>

### Checklist:

* [x] Have you added Draft Release Notes in `docs/draft-release-notes.md`?
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

