### PR TITLE
test: only upgrade instances if upgrade available

### DIFF
--- a/acceptance-tests/helpers/services/upgrade.go
+++ b/acceptance-tests/helpers/services/upgrade.go
@@ -10,7 +10,10 @@ import (
 )
 
 func (s *ServiceInstance) Upgrade() {
-	Expect(s.UpgradeAvailable()).To(BeTrue(), "service instance does not have an upgrade available")
+	if !s.UpgradeAvailable() {
+		fmt.Printf("no upgrade available for service instance\n")
+		return
+	}
 
 	var command []string
 	switch cf.Version() {


### PR DESCRIPTION
For cases where there is no upgrade available due to the Terraform Version being identical between brokers, we no longer assert that there should be an upgrade. 

[#182757139](https://www.pivotaltracker.com/story/show/182757139)

Signed-off-by: Konstantin Semenov <ksemenov@vmware.com>

### Checklist:

* [ ] Have you added Draft Release Notes in `docs/draft-release-notes.md`?
* [ ] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

