### PR TITLE
chore: push the broker faster

### DIFF
--- a/acceptance-tests/helpers/apps/app.go
+++ b/acceptance-tests/helpers/apps/app.go
@@ -8,6 +8,5 @@ type App struct {
 	buildpack string
 	memory    string
 	manifest  string
-	variables map[string]string
 	dir       dir
 }

--- a/acceptance-tests/helpers/apps/push.go
+++ b/acceptance-tests/helpers/apps/push.go
@@ -39,10 +39,6 @@ func (a *App) Push(opts ...Option) {
 		cmd = append(cmd, "-f", a.manifest)
 	}
 
-	for k, v := range a.variables {
-		cmd = append(cmd, "--var", fmt.Sprintf("%s=%s", k, v))
-	}
-
 	if a.dir.path() == "" {
 		Fail("App directory must be specified")
 	}
@@ -89,15 +85,6 @@ func WithDir(dir string) Option {
 func WithManifest(manifest string) Option {
 	return func(a *App) {
 		a.manifest = manifest
-	}
-}
-
-func WithVariable(key, value string) Option {
-	return func(a *App) {
-		if a.variables == nil {
-			a.variables = make(map[string]string)
-		}
-		a.variables[key] = value
 	}
 }
 

--- a/acceptance-tests/helpers/apps/setenv.go
+++ b/acceptance-tests/helpers/apps/setenv.go
@@ -12,23 +12,28 @@ type EnvVar struct {
 	Value any
 }
 
+func (e EnvVar) ValueString() string {
+	switch v := e.Value.(type) {
+	case string:
+		return v
+	default:
+		data, err := json.Marshal(v)
+		Expect(err).NotTo(HaveOccurred())
+		return string(data)
+	}
+}
+
 func (a *App) SetEnv(env ...EnvVar) {
 	SetEnv(a.Name, env...)
 }
 
 func SetEnv(name string, env ...EnvVar) {
 	for _, envVar := range env {
-		switch v := envVar.Value.(type) {
-		case string:
-			if v == "" {
-				cf.Run("unset-env", name, envVar.Name)
-			} else {
-				cf.Run("set-env", name, envVar.Name, v)
-			}
-		default:
-			data, err := json.Marshal(v)
-			Expect(err).NotTo(HaveOccurred())
-			cf.Run("set-env", name, envVar.Name, string(data))
+		v := envVar.ValueString()
+		if v == "" {
+			cf.Run("unset-env", name, envVar.Name)
+		} else {
+			cf.Run("set-env", name, envVar.Name, v)
 		}
 	}
 }

--- a/acceptance-tests/helpers/brokers/create.go
+++ b/acceptance-tests/helpers/brokers/create.go
@@ -17,10 +17,11 @@ func Create(opts ...Option) *Broker {
 	brokerApp := apps.Push(
 		apps.WithName(broker.Name),
 		apps.WithDir(broker.dir),
-		apps.WithManifest(fmt.Sprintf("%s/cf-manifest.yml", broker.dir)),
-		apps.WithVariable("app", broker.Name),
+		apps.WithManifest(newManifest(
+			withName(broker.Name),
+			withEnv(broker.env()...),
+		)),
 	)
-	brokerApp.SetEnv(broker.env()...)
 
 	schemaName := strings.ReplaceAll(broker.Name, "-", "_")
 	cf.Run("bind-service", broker.Name, "csb-sql", "-c", fmt.Sprintf(`{"schema":"%s"}`, schemaName))

--- a/acceptance-tests/helpers/brokers/manifest.go
+++ b/acceptance-tests/helpers/brokers/manifest.go
@@ -1,0 +1,71 @@
+package brokers
+
+import (
+	"csbbrokerpakgcp/acceptance-tests/helpers/apps"
+	"os"
+	"path/filepath"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	"gopkg.in/yaml.v3"
+)
+
+func newManifest(opts ...manifestOption) string {
+	m := manifestModel{
+		Version: 1,
+		Applications: []applicationModel{
+			{
+				Command:     "./cloud-service-broker serve",
+				Memory:      "500MB",
+				Disk:        "2G",
+				Buildpacks:  []string{"binary_buildpack"},
+				RandomRoute: true,
+				Environment: make(map[string]string),
+			},
+		},
+	}
+
+	for _, o := range opts {
+		o(&m)
+	}
+
+	data, err := yaml.Marshal(m)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	dir := ginkgo.GinkgoT().TempDir()
+	path := filepath.Join(dir, "manifest.yml")
+	gomega.Expect(os.WriteFile(path, data, 0666)).To(gomega.Succeed())
+
+	return path
+}
+
+type manifestOption func(*manifestModel)
+
+type manifestModel struct {
+	Version      int                `yaml:"version"`
+	Applications []applicationModel `yaml:"applications"`
+}
+
+type applicationModel struct {
+	Name        string            `yaml:"name"`
+	Command     string            `yaml:"command"`
+	Memory      string            `yaml:"memory,omitempty"`
+	Disk        string            `yaml:"disk_quota,omitempty"`
+	Buildpacks  []string          `yaml:"buildpacks,omitempty"`
+	RandomRoute bool              `yaml:"random-route"`
+	Environment map[string]string `yaml:"env,omitempty"`
+}
+
+func withName(name string) manifestOption {
+	return func(m *manifestModel) {
+		m.Applications[0].Name = name
+	}
+}
+
+func withEnv(env ...apps.EnvVar) manifestOption {
+	return func(m *manifestModel) {
+		for _, e := range env {
+			m.Applications[0].Environment[e.Name] = e.ValueString()
+		}
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	golang.org/x/tools v0.1.11-0.20220513221640-090b14e8501f
 	google.golang.org/api v0.87.0
 	google.golang.org/genproto v0.0.0-20220624142145-8cd45d7dbd1f
+	gopkg.in/yaml.v3 v3.0.1
 	honnef.co/go/tools v0.3.2
 )
 
@@ -129,7 +130,6 @@ require (
 	google.golang.org/protobuf v1.28.0 // indirect
 	gopkg.in/ini.v1 v1.66.4 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	gorm.io/driver/mysql v1.3.4 // indirect
 	gorm.io/driver/sqlite v1.3.6 // indirect
 	gorm.io/gorm v1.23.8 // indirect


### PR DESCRIPTION
By skipping repeated "cf set-env" commands and instead putting the
environment variables in the manifest, this change results in faster
deployment of the broker

[#182771270](https://www.pivotaltracker.com/story/show/182771270)

### Checklist:

* ~~[ ] Have you added Draft Release Notes in `docs/draft-release-notes.md`?~~
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

