### PR TITLE
build(deps): fix previous bump terraform provider

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -33,7 +33,7 @@ terraform_binaries:
 - name: terraform-provider-csbpg
   version: 1.0.1
   source: https://github.com/cloudfoundry/terraform-provider-csbpg/archive/v1.0.1.zip
-  source: https://github.com/cloudfoundry/terraform-provider-csbpg/archive/v1.0.0.zip
+  provider: cloud-service-broker/csbpg
   url_template: https://github.com/cloudfoundry/${name}/releases/download/v${version}/${name}_${version}_${os}_${arch}.zip
 env_config_mapping:
   GOOGLE_CREDENTIALS: gcp.credentials


### PR DESCRIPTION
It seems that the script that updates Terraform providers expects fields
in a certain order: name, version, source. If we keep things in that
order then it will work correctly. We plan to rework the provider update
in https://www.pivotaltracker.com/story/show/181478730, so it's not
worth improving the current script to be more flexible.

[#182961253](https://www.pivotaltracker.com/story/show/182961253)

### Checklist:

* ~~[ ] Have you added Draft Release Notes in `docs/draft-release-notes.md`?~~
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

