### PR TITLE
test: fix flake in Spanner test

### DIFF
--- a/acceptance-tests/helpers/apps/prebuild.go
+++ b/acceptance-tests/helpers/apps/prebuild.go
@@ -21,7 +21,7 @@ func WithPreBuild(source string) Option {
 
 	session, err := gexec.Start(command, ginkgo.GinkgoWriter, ginkgo.GinkgoWriter)
 	Expect(err).NotTo(HaveOccurred())
-	Eventually(session, time.Minute).Should(gexec.Exit(0))
+	Eventually(session, 5*time.Minute).Should(gexec.Exit(0))
 
 	err = os.WriteFile(path.Join(dir.path(), "Procfile"), []byte(fmt.Sprintf("web: ./%s\n", name)), 0555)
 	Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
The Spanner acceptance test tries to build a Spanner app. For some reason this build is comparatively slow for a Go app. It often takes 50 seconds in CI, and took 90 seconds on my workstation. The timeout is 60 seconds, hence 8 failures in the past week when it went over the timeout. I've therefore increased the timeout to 5 minutes, so when it times out we know that something remarkable has happened, rather that just being a little slower than usual.