### PR TITLE
chore: revert "feat: [mysql] enable TLS"

### DIFF
--- a/acceptance-tests/apps/mysqlapp/internal/credentials/credentials.go
+++ b/acceptance-tests/apps/mysqlapp/internal/credentials/credentials.go
@@ -2,6 +2,7 @@ package credentials
 
 import (
 	"fmt"
+	"strconv"
 
 	"github.com/cloudfoundry-community/go-cfenv"
 	"github.com/go-sql-driver/mysql"
@@ -36,7 +37,7 @@ func Read() (*mysql.Config, error) {
 	}
 
 	c := mysql.NewConfig()
-	c.TLSConfig = "true"
+	c.TLSConfig = strconv.FormatBool(m.UseTLS)
 	c.Net = "tcp"
 	c.Addr = m.Host
 	c.User = m.Username

--- a/google-mysql.yml
+++ b/google-mysql.yml
@@ -193,15 +193,9 @@ provision:
   - field_name: password
     type: string
     details: The password to authenticate to the database instance.
-  - field_name: sslrootcert
-    type: string
-    details: Root CA for the database instance.
-  - field_name: sslcert
-    type: string
-    details: Client certificate for establishing a mutual TLS connection with the database instance.
-  - field_name: sslkey
-    type: string
-    details: Client private key for establishing a mutual TLS connection with the database instance.
+  - field_name: use_tls
+    type: boolean
+    details: Using TLS for connection
 bind:
   plan_inputs: []
   user_inputs: []
@@ -226,15 +220,10 @@ bind:
     type: string
     default: ${instance.details["password"]}
     overwrite: true
-  - name: sslrootcert
-    type: string
-    default: ${instance.details["sslrootcert"]}
-  - name: sslcert
-    type: string
-    default: ${instance.details["sslcert"]}
-  - name: sslkey
-    type: string
-    default: ${instance.details["sslkey"]}
+  - name: use_tls
+    type: boolean
+    default: ${instance.details["use_tls"]}
+    overwrite: true
   template_refs:
     provider: terraform/cloudsql/mysql/bind/provider.tf
     versions: terraform/cloudsql/mysql/bind/versions.tf
@@ -257,15 +246,6 @@ bind:
   - field_name: jdbcUrl
     type: string
     details: The jdbc url to connect to the database instance and database.
-  - field_name: sslrootcert
-    type: string
-    details: Root CA for the database instance.
-  - field_name: sslcert
-    type: string
-    details: Client certificate for establishing a mutual TLS connection.
-  - field_name: sslkey
-    type: string
-    details: Client private key for establishing a mutual TLS connection.
 examples:
 - name: small configuration
   description: Create a small mysql instance

--- a/terraform-tests/mysql_test.go
+++ b/terraform-tests/mysql_test.go
@@ -111,7 +111,7 @@ var _ = Describe("mysql", Label("mysql-terraform"), Ordered, func() {
 	})
 
 	Context("backups", func() {
-		Specify("disabling", func() {
+		Specify("disabling backups", func() {
 			plan = ShowPlan(terraformProvisionDir, buildVars(defaultVars, map[string]any{"backups_retain_number": 0}))
 
 			Expect(AfterValuesForType(plan, googleSQLDBInstance)).To(
@@ -125,7 +125,7 @@ var _ = Describe("mysql", Label("mysql-terraform"), Ordered, func() {
 			)
 		})
 
-		Specify("enabling transaction log", func() {
+		Specify("enabling transaction log backups", func() {
 			plan = ShowPlan(terraformProvisionDir, buildVars(defaultVars, map[string]any{"backups_transaction_log_retention_days": 3}))
 
 			Expect(AfterValuesForType(plan, googleSQLDBInstance)).To(
@@ -171,16 +171,6 @@ var _ = Describe("mysql", Label("mysql-terraform"), Ordered, func() {
 					})),
 				}),
 			)
-		})
-	})
-
-	Context("TLS", func() {
-		It("generates the artefacts", func() {
-			plan = ShowPlan(terraformProvisionDir, buildVars(defaultVars, map[string]any{}))
-
-			Expect(AfterValuesForType(plan, "google_sql_ssl_cert")).To(MatchKeys(IgnoreExtras, Keys{
-				"instance": Equal("test-instance-name-456"),
-			}))
 		})
 	})
 })

--- a/terraform/cloudsql/mysql/bind/main.tf
+++ b/terraform/cloudsql/mysql/bind/main.tf
@@ -1,7 +1,7 @@
 resource "random_string" "username" {
   length  = 16
   special = false
-  numeric = false
+  number  = false
 }
 
 resource "random_password" "password" {

--- a/terraform/cloudsql/mysql/bind/outputs.tf
+++ b/terraform/cloudsql/mysql/bind/outputs.tf
@@ -15,16 +15,11 @@ output "uri" {
 output "port" { value = local.port }
 output "jdbcUrl" {
   sensitive = true
-  value = format("jdbc:mysql://%s:%d/%s?user=%s\u0026password=%s\u0026sslMode=REQUIRED",
+  value = format("jdbc:mysql://%s:%d/%s?user=%s\u0026password=%s\u0026useSSL=%v",
     var.mysql_hostname,
     local.port,
     var.mysql_db_name,
     mysql_user.newuser.user,
-  random_password.password.result)
-}
-output "sslrootcert" { value = var.sslrootcert }
-output "sslcert" { value = var.sslcert }
-output "sslkey" {
-  sensitive = true
-  value     = var.sslkey
+    random_password.password.result,
+  var.use_tls)
 }

--- a/terraform/cloudsql/mysql/bind/variables.tf
+++ b/terraform/cloudsql/mysql/bind/variables.tf
@@ -6,13 +6,7 @@ variable "admin_password" {
   sensitive = true
   type      = string
 }
-
-variable "sslrootcert" { type = string }
-variable "sslcert" { type = string }
-variable "sslkey" {
-  sensitive = true
-  type      = string
-}
+variable "use_tls" { type = bool }
 
 locals {
   port = 3306

--- a/terraform/cloudsql/mysql/provision/main.tf
+++ b/terraform/cloudsql/mysql/provision/main.tf
@@ -66,8 +66,3 @@ resource "google_sql_user" "admin_user" {
   instance = google_sql_database_instance.instance.name
   password = random_password.password.result
 }
-
-resource "google_sql_ssl_cert" "client_cert" {
-  common_name = random_string.username.result
-  instance    = google_sql_database_instance.instance.name
-}

--- a/terraform/cloudsql/mysql/provision/outputs.tf
+++ b/terraform/cloudsql/mysql/provision/outputs.tf
@@ -7,10 +7,4 @@ output "password" {
   sensitive = true
   value     = google_sql_user.admin_user.password
 }
-
-output "sslrootcert" { value = google_sql_database_instance.instance.server_ca_cert.0.cert }
-output "sslcert" { value = google_sql_ssl_cert.client_cert.cert }
-output "sslkey" {
-  value     = google_sql_ssl_cert.client_cert.private_key
-  sensitive = true
-}
+output "use_tls" { value = false }

--- a/terraform/cloudsql/postgresql/provision/variables.tf
+++ b/terraform/cloudsql/postgresql/provision/variables.tf
@@ -15,9 +15,6 @@ variable "backups_location" { type = string }
 variable "backups_start_time" { type = string }
 variable "backups_point_in_time_log_retain_days" { type = number }
 
-variable "credentials" {
-  type      = string
-  sensitive = true
-}
+variable "credentials" { type = string }
 variable "project" { type = string }
 variable "require_ssl" { type = bool }


### PR DESCRIPTION
Reverts cloudfoundry/csb-brokerpak-gcp#592

Acceptance tests do not pass correctly: 
```
failed to create test table: x509: cannot validate certificate for 10.160.104.9 because it doesn't contain any IP SANs
```