### PR TITLE
test: improve matching in integration tests

### DIFF
--- a/integration-tests/integration_tests_suite_test.go
+++ b/integration-tests/integration_tests_suite_test.go
@@ -23,6 +23,8 @@ var (
 const (
 	brokerGCPProject = "broker-gcp-project"
 	brokerGCPCreds   = "broker-gcp-creds"
+	Name             = "Name"
+	ID               = "ID"
 )
 
 var _ = BeforeSuite(func() {
@@ -37,9 +39,9 @@ var _ = BeforeSuite(func() {
 		"GSB_COMPATIBILITY_ENABLE_BETA_SERVICES=true",
 		"GOOGLE_CREDENTIALS=" + brokerGCPCreds,
 		"GOOGLE_PROJECT=" + brokerGCPProject,
-		`GSB_SERVICE_CSB_GOOGLE_POSTGRES_PLANS=` + marshall(postgresPlans),
-		"GSB_SERVICE_CSB_GOOGLE_MYSQL_PLANS=" + marshall(customMySQLPlans),
-		"GSB_SERVICE_CSB_GOOGLE_REDIS_PLANS=" + marshall(customRedisPlans),
+		`GSB_SERVICE_CSB_GOOGLE_POSTGRES_PLANS=` + marshal(postgresPlans),
+		"GSB_SERVICE_CSB_GOOGLE_MYSQL_PLANS=" + marshal(customMySQLPlans),
+		"GSB_SERVICE_CSB_GOOGLE_REDIS_PLANS=" + marshal(customRedisPlans),
 		"CSB_LISTENER_HOST=localhost", // prevents permissions popup
 	})).To(Succeed())
 })
@@ -50,7 +52,7 @@ var _ = AfterSuite(func() {
 	}
 })
 
-func marshall(element any) string {
+func marshal(element any) string {
 	b, err := json.Marshal(element)
 	Expect(err).NotTo(HaveOccurred())
 	return string(b)

--- a/integration-tests/mysql_test.go
+++ b/integration-tests/mysql_test.go
@@ -10,8 +10,14 @@ import (
 )
 
 const (
-	mySQLServiceName    = "csb-google-mysql"
-	customMySQLPlanName = "custom-plan"
+	mySQLServiceName             = "csb-google-mysql"
+	mySQLServiceID               = "b9f3d4f3-8716-4179-8b7c-e80bd5bccb31"
+	mySQLServiceDisplayName      = "Google Cloud Mysql (Beta)"
+	mySQLServiceDocumentationURL = "https://cloud.google.com/sql/docs/mysql/"
+	mySQLServiceDescription      = "Beta - Mysql is a fully managed service for the Google Cloud Platform."
+	mySQLServiceSupportURL       = "https://cloud.google.com/support/"
+	mySQLCustomPlanName          = "custom-plan"
+	mySQLCustomPlanID            = "9daa07f1-78e8-4bda-9efe-91576102c30d"
 )
 
 var customMySQLPlans = []map[string]any{
@@ -19,8 +25,8 @@ var customMySQLPlans = []map[string]any{
 }
 
 var customMySQLPlan = map[string]any{
-	"name":          customMySQLPlanName,
-	"id":            "9daa07f1-78e8-4bda-9efe-91576102c30d",
+	"name":          mySQLCustomPlanName,
+	"id":            mySQLCustomPlanID,
 	"description":   "custom plan defined by customer",
 	"mysql_version": "MYSQL_5_7",
 	"metadata": map[string]any{
@@ -28,7 +34,7 @@ var customMySQLPlan = map[string]any{
 	},
 }
 
-var _ = Describe("Mysql", Label("MySQL"), func() {
+var _ = Describe("MySQL", Label("MySQL"), func() {
 	BeforeEach(func() {
 		Expect(mockTerraform.SetTFState([]testframework.TFStateValue{})).NotTo(HaveOccurred())
 	})
@@ -42,21 +48,26 @@ var _ = Describe("Mysql", Label("MySQL"), func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		service := testframework.FindService(catalog, mySQLServiceName)
-		Expect(service.ID).NotTo(BeNil())
-		Expect(service.Name).NotTo(BeNil())
+		Expect(service.ID).To(Equal(mySQLServiceID))
+		Expect(service.Description).To(Equal(mySQLServiceDescription))
 		Expect(service.Tags).To(ConsistOf("gcp", "mysql", "beta"))
-		Expect(service.Metadata.ImageUrl).NotTo(BeNil())
-		Expect(service.Metadata.DisplayName).NotTo(BeNil())
+		Expect(service.Metadata.ImageUrl).To(ContainSubstring("data:image/png;base64,"))
+		Expect(service.Metadata.DisplayName).To(Equal(mySQLServiceDisplayName))
+		Expect(service.Metadata.DocumentationUrl).To(Equal(mySQLServiceDocumentationURL))
+		Expect(service.Metadata.SupportUrl).To(Equal(mySQLServiceSupportURL))
 		Expect(service.Plans).To(
 			ConsistOf(
-				MatchFields(IgnoreExtras, Fields{"Name": Equal("custom-plan")}),
+				MatchFields(IgnoreExtras, Fields{
+					ID:   Equal(mySQLCustomPlanID),
+					Name: Equal(mySQLCustomPlanName),
+				}),
 			),
 		)
 	})
 
 	Describe("provisioning", func() {
 		It("should provision a plan", func() {
-			instanceID, err := broker.Provision(mySQLServiceName, customMySQLPlanName, map[string]any{"tier": "db-n1-standard-1"})
+			instanceID, err := broker.Provision(mySQLServiceName, mySQLCustomPlanName, map[string]any{"tier": "db-n1-standard-1"})
 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(mockTerraform.FirstTerraformInvocationVars()).To(
@@ -86,7 +97,7 @@ var _ = Describe("Mysql", Label("MySQL"), func() {
 		})
 
 		It("should allow setting properties not defined in the plan", func() {
-			_, err := broker.Provision(mySQLServiceName, customMySQLPlanName, map[string]any{
+			_, err := broker.Provision(mySQLServiceName, mySQLCustomPlanName, map[string]any{
 				"credentials":                            "fake-credentials",
 				"project":                                "fake-project",
 				"instance_name":                          "fakeinstancename",
@@ -129,14 +140,14 @@ var _ = Describe("Mysql", Label("MySQL"), func() {
 		})
 
 		It("should not allow changing of plan defined properties", func() {
-			_, err := broker.Provision(mySQLServiceName, customMySQLPlanName, map[string]any{"mysql_version": "MYSQL_8_0"})
+			_, err := broker.Provision(mySQLServiceName, mySQLCustomPlanName, map[string]any{"mysql_version": "MYSQL_8_0"})
 
 			Expect(err).To(MatchError(ContainSubstring("plan defined properties cannot be changed: mysql_version")))
 		})
 
 		DescribeTable("property constraints",
 			func(params map[string]any, expectedErrorMsg string) {
-				_, err := broker.Provision(mySQLServiceName, customMySQLPlanName, params)
+				_, err := broker.Provision(mySQLServiceName, mySQLCustomPlanName, params)
 
 				Expect(err).To(MatchError(ContainSubstring(expectedErrorMsg)))
 			},
@@ -203,14 +214,14 @@ var _ = Describe("Mysql", Label("MySQL"), func() {
 
 		BeforeEach(func() {
 			var err error
-			instanceID, err = broker.Provision(mySQLServiceName, customMySQLPlanName, map[string]any{"tier": "db-n1-standard-1"})
+			instanceID, err = broker.Provision(mySQLServiceName, mySQLCustomPlanName, map[string]any{"tier": "db-n1-standard-1"})
 
 			Expect(err).NotTo(HaveOccurred())
 		})
 
 		DescribeTable("should allow updating properties not flagged as `prohibit_update` and not specified in the plan",
 			func(params map[string]any) {
-				err := broker.Update(instanceID, mySQLServiceName, customMySQLPlanName, params)
+				err := broker.Update(instanceID, mySQLServiceName, mySQLCustomPlanName, params)
 
 				Expect(err).NotTo(HaveOccurred())
 			},
@@ -231,7 +242,7 @@ var _ = Describe("Mysql", Label("MySQL"), func() {
 
 		DescribeTable("should prevent updating properties flagged as `prohibit_update` because it can result in the recreation of the service instance and lost data",
 			func(params map[string]any) {
-				err := broker.Update(instanceID, mySQLServiceName, customMySQLPlanName, params)
+				err := broker.Update(instanceID, mySQLServiceName, mySQLCustomPlanName, params)
 
 				Expect(err).To(MatchError(
 					ContainSubstring(
@@ -250,7 +261,7 @@ var _ = Describe("Mysql", Label("MySQL"), func() {
 
 		DescribeTable("should not allow updating properties that are specified in the plan",
 			func(key string, value any) {
-				err := broker.Update(instanceID, mySQLServiceName, customMySQLPlanName, map[string]any{key: value})
+				err := broker.Update(instanceID, mySQLServiceName, mySQLCustomPlanName, map[string]any{key: value})
 
 				Expect(err).To(
 					MatchError(
@@ -265,7 +276,7 @@ var _ = Describe("Mysql", Label("MySQL"), func() {
 
 		DescribeTable("should not allow updating additional properties",
 			func(key string, value any) {
-				err := broker.Update(instanceID, mySQLServiceName, customMySQLPlanName, map[string]any{key: value})
+				err := broker.Update(instanceID, mySQLServiceName, mySQLCustomPlanName, map[string]any{key: value})
 
 				Expect(err).To(
 					MatchError(
@@ -279,5 +290,4 @@ var _ = Describe("Mysql", Label("MySQL"), func() {
 			Entry("update id", "id", "fake-id"),
 		)
 	})
-
 })

--- a/integration-tests/postgres_test.go
+++ b/integration-tests/postgres_test.go
@@ -7,6 +7,15 @@ import (
 	. "github.com/onsi/gomega/gstruct"
 )
 
+const (
+	postgresServiceName             = "csb-google-postgres"
+	postgresServiceID               = "40501b82-cb90-11ec-b1c2-e3a703778055"
+	postgresServiceDescription      = "PostgreSQL is a fully managed service for the Google Cloud Platform."
+	postgresServiceDisplayName      = "Google Cloud PostgreSQL"
+	postgresServiceDocumentationURL = "https://cloud.google.com/sql/docs/postgres"
+	postgresServiceSupportURL       = "https://cloud.google.com/support/"
+)
+
 var postgresNoOverridesPlan = map[string]any{
 	"name":        "no-overrides",
 	"id":          "5f60d632-8f1e-11ec-9832-7bd519d660a9",
@@ -47,16 +56,24 @@ var _ = Describe("postgres", Label("postgres"), func() {
 		catalog, err := broker.Catalog()
 		Expect(err).NotTo(HaveOccurred())
 
-		service := testframework.FindService(catalog, "csb-google-postgres")
-		Expect(service.ID).NotTo(BeNil())
-		Expect(service.Name).NotTo(BeNil())
+		service := testframework.FindService(catalog, postgresServiceName)
+		Expect(service.ID).To(Equal(postgresServiceID))
+		Expect(service.Description).To(Equal(postgresServiceDescription))
 		Expect(service.Tags).To(ConsistOf("gcp", "postgresql", "postgres"))
-		Expect(service.Metadata.ImageUrl).NotTo(BeNil())
-		Expect(service.Metadata.DisplayName).NotTo(BeNil())
+		Expect(service.Metadata.ImageUrl).To(ContainSubstring("data:image/png;base64,"))
+		Expect(service.Metadata.DisplayName).To(Equal(postgresServiceDisplayName))
+		Expect(service.Metadata.DocumentationUrl).To(Equal(postgresServiceDocumentationURL))
+		Expect(service.Metadata.SupportUrl).To(Equal(postgresServiceSupportURL))
 		Expect(service.Plans).To(
 			ConsistOf(
-				MatchFields(IgnoreExtras, Fields{"Name": Equal("all-overrides")}),
-				MatchFields(IgnoreExtras, Fields{"Name": Equal("no-overrides")}),
+				MatchFields(IgnoreExtras, Fields{
+					ID:   Equal("4be43944-8f20-11ec-9ea5-834eb2499c32"),
+					Name: Equal("all-overrides"),
+				}),
+				MatchFields(IgnoreExtras, Fields{
+					ID:   Equal("5f60d632-8f1e-11ec-9832-7bd519d660a9"),
+					Name: Equal("no-overrides"),
+				}),
 			),
 		)
 	})

--- a/integration-tests/redis_test.go
+++ b/integration-tests/redis_test.go
@@ -9,6 +9,15 @@ import (
 	. "github.com/onsi/gomega/gstruct"
 )
 
+const (
+	redisServiceName             = "csb-google-redis"
+	redisServiceID               = "0e86ad78-99b3-48b6-a986-b594e7995fd6"
+	redisServiceDescription      = "Beta - Cloud Memorystore for Redis is a fully managed Redis service for the Google Cloud Platform."
+	redisServiceDisplayName      = "Google Cloud Memorystore for Redis (Beta)"
+	redisServiceDocumentationURL = "https://cloud.google.com/memorystore/docs/redis/"
+	redisServiceSupportURL       = "https://cloud.google.com/support/"
+)
+
 var customRedisPlans = []map[string]any{
 	customRedisPlan,
 }
@@ -28,8 +37,6 @@ var customRedisPlan = map[string]any{
 }
 
 var _ = Describe("Redis", func() {
-	const redisServiceName = "csb-google-redis"
-
 	BeforeEach(func() {
 		Expect(mockTerraform.SetTFState([]testframework.TFStateValue{})).To(Succeed())
 	})
@@ -43,16 +50,27 @@ var _ = Describe("Redis", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		service := testframework.FindService(catalog, redisServiceName)
-		Expect(service.ID).NotTo(BeNil())
-		Expect(service.Name).NotTo(BeNil())
+		Expect(service.ID).To(Equal(redisServiceID))
+		Expect(service.Description).To(Equal(redisServiceDescription))
 		Expect(service.Tags).To(ConsistOf("gcp", "redis", "beta"))
-		Expect(service.Metadata.ImageUrl).NotTo(BeNil())
-		Expect(service.Metadata.DisplayName).NotTo(BeNil())
+		Expect(service.Metadata.ImageUrl).To(ContainSubstring("data:image/png;base64,"))
+		Expect(service.Metadata.DisplayName).To(Equal(redisServiceDisplayName))
+		Expect(service.Metadata.DocumentationUrl).To(Equal(redisServiceDocumentationURL))
+		Expect(service.Metadata.SupportUrl).To(Equal(redisServiceSupportURL))
 		Expect(service.Plans).To(
 			ConsistOf(
-				MatchFields(IgnoreExtras, Fields{"Name": Equal("basic")}),
-				MatchFields(IgnoreExtras, Fields{"Name": Equal("ha")}),
-				MatchFields(IgnoreExtras, Fields{"Name": Equal("custom-plan")}),
+				MatchFields(IgnoreExtras, Fields{
+					Name: Equal("basic"),
+					ID:   Equal("6ed44104-8777-4b57-8c03-826b3af7d0be"),
+				}),
+				MatchFields(IgnoreExtras, Fields{
+					Name: Equal("ha"),
+					ID:   Equal("8c85c90c-f8e3-4337-9069-c03036243894"),
+				}),
+				MatchFields(IgnoreExtras, Fields{
+					Name: Equal("custom-plan"),
+					ID:   Equal("9dfa265e-1c4d-40c6-ade6-b341ffd6ccc3"),
+				}),
 			),
 		)
 	})


### PR DESCRIPTION
The integration tests contained a lot of:
```
Expect(foo).ToNot(BeNil())
```
which for a string value can never fail. These tests have been improved to match against expected data.
