### PR TITLE
fix: capitalization of MySQL

### DIFF
--- a/acceptance-tests/mysql_test.go
+++ b/acceptance-tests/mysql_test.go
@@ -13,7 +13,7 @@ import (
 	"csbbrokerpakgcp/acceptance-tests/helpers/services"
 )
 
-var _ = Describe("Mysql", Label("mysql"), func() {
+var _ = Describe("MySQL", Label("mysql"), func() {
 	It("can be accessed by an app", func() {
 		By("creating a service instance")
 		serviceInstance := services.CreateInstance("csb-google-mysql", "default")

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -149,7 +149,7 @@ make push-broker
 Once this completes, the output from `cf marketplace` should include:
 
 ```
-csb-google-mysql            small, medium, large   Mysql is a fully managed service for the Google Cloud Platform.
+csb-google-mysql            small, medium, large   MySQL is a fully managed service for the Google Cloud Platform.
 
 csb-google-postgres         small, medium, large   PostgreSQL is a fully managed service for the Google Cloud Platform.
 

--- a/google-mysql.yml
+++ b/google-mysql.yml
@@ -15,9 +15,9 @@
 version: 1
 name: csb-google-mysql
 id: b9f3d4f3-8716-4179-8b7c-e80bd5bccb31
-description: Beta - Mysql is a fully managed service for the
+description: Beta - MySQL is a fully managed service for the
   Google Cloud Platform.
-display_name: Google Cloud Mysql (Beta)
+display_name: Google Cloud MySQL (Beta)
 image_url: file://service-images/csb.png
 documentation_url: https://cloud.google.com/sql/docs/mysql/
 support_url: https://cloud.google.com/support/

--- a/integration-tests/mysql_test.go
+++ b/integration-tests/mysql_test.go
@@ -12,9 +12,9 @@ import (
 const (
 	mySQLServiceName             = "csb-google-mysql"
 	mySQLServiceID               = "b9f3d4f3-8716-4179-8b7c-e80bd5bccb31"
-	mySQLServiceDisplayName      = "Google Cloud Mysql (Beta)"
+	mySQLServiceDisplayName      = "Google Cloud MySQL (Beta)"
 	mySQLServiceDocumentationURL = "https://cloud.google.com/sql/docs/mysql/"
-	mySQLServiceDescription      = "Beta - Mysql is a fully managed service for the Google Cloud Platform."
+	mySQLServiceDescription      = "Beta - MySQL is a fully managed service for the Google Cloud Platform."
 	mySQLServiceSupportURL       = "https://cloud.google.com/support/"
 	mySQLCustomPlanName          = "custom-plan"
 	mySQLCustomPlanID            = "9daa07f1-78e8-4bda-9efe-91576102c30d"


### PR DESCRIPTION
It was referred to as "Mysql" in places, which does not match the MySQL branding.