### PR TITLE
chore: TLS is disabled when using the old bind format

### DIFF
--- a/acceptance-tests/apps/mysqlapp/internal/credentials/credentials.go
+++ b/acceptance-tests/apps/mysqlapp/internal/credentials/credentials.go
@@ -42,7 +42,7 @@ func Read() (string, error) {
 	}
 
 	c := mysql.NewConfig()
-	c.TLSConfig = "true"
+	c.TLSConfig = "false"
 	c.Net = "tcp"
 	c.Addr = fmt.Sprintf("%s:%d", m.Host, m.Port)
 	c.User = m.Username


### PR DESCRIPTION
[#184053043](https://www.pivotaltracker.com/story/show/184053043)

### Checklist:

* ~~[ ] Have you added Release Notes in the docs repositories?~~
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

