### PR TITLE
chore: avoid recreation bucket using the dynamic block

### DIFF
--- a/terraform-tests/storage_test.go
+++ b/terraform-tests/storage_test.go
@@ -64,11 +64,7 @@ var _ = Describe("storage", Label("storage-terraform"), Ordered, func() {
 							"default_kms_key_name": Equal("projects/project/locations/location/keyRings/key-ring-name/cryptoKeys/key-name"),
 						}),
 					),
-					"autoclass": ConsistOf(
-						MatchAllKeys(Keys{
-							"enabled": BeFalse(),
-						}),
-					),
+					"autoclass": BeEmpty(),
 				}),
 			)
 		})

--- a/terraform/storage/provision/main.tf
+++ b/terraform/storage/provision/main.tf
@@ -26,8 +26,11 @@ resource "google_storage_bucket" "bucket" {
     }
   }
 
-  autoclass {
-    enabled = var.autoclass
+  dynamic "autoclass" {
+    for_each = var.autoclass ? [true] : []
+    content {
+      enabled = var.autoclass
+    }
   }
 
   lifecycle {


### PR DESCRIPTION
We need to use the dynamic block when defining the autoclass block to avoid setting the property when updating the service and not recreating the bucket.

[#184267802](https://www.pivotaltracker.com/story/show/184267802)

### Checklist:

* ~~[ ] Have you added Release Notes in the docs repositories?~~
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

