### PR TITLE
chore: improve constraints in bucket name

### DIFF
--- a/google-storage.yml
+++ b/google-storage.yml
@@ -35,8 +35,18 @@ provision:
   user_inputs:
   - field_name: name
     type: string
-    details: Name of bucket
+    details: |
+      Name of bucket.
+      To see the requirements the name must meet, see https://cloud.google.com/storage/docs/buckets#naming.
+      Names containing dots require verification, see https://cloud.google.com/storage/docs/domain-name-verification.
     default: csb-${request.instance_id}
+    prohibit_update: true
+    constraints:
+      examples:
+        - my-bucket
+        - 0f75d593-8e7b-4418-a5ba-cb2970f0b91e
+        - test.example.com
+      pattern: ^[a-z0-9][a-z0-9_.-]{1,220}[a-z0-9]$
   - field_name: storage_class
     type: string
     details: |


### PR DESCRIPTION
Added the same regular expression used in the Terraform provider, in this way we will get a faster feedback.
The TF provider forces the recreation of the bucket when changing the name. Added `prohibit_update` to avoid it.

[#184053558](https://www.pivotaltracker.com/story/show/184053558)

### Checklist:

* [x] Have you added Release Notes in the docs repositories?
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

