### PR TITLE
test: separate out released and development env vars

### DIFF
--- a/acceptance-tests/cloudsql_mysql_migration_test.go
+++ b/acceptance-tests/cloudsql_mysql_migration_test.go
@@ -21,6 +21,7 @@ var _ = Describe("MySQL service instance migration", Label("mysql-data-migration
 
 		serviceBroker := brokers.Create(
 			brokers.WithPrefix("csb-mysql"),
+			brokers.WithLatestEnv(),
 			brokers.WithEnv(apps.EnvVar{Name: brokers.PlansMySQLVar, Value: mysql56plan}),
 		)
 		defer serviceBroker.Delete()

--- a/acceptance-tests/helpers/brokers/env.go
+++ b/acceptance-tests/helpers/brokers/env.go
@@ -15,7 +15,6 @@ const (
 	plansStorageVar    = "GSB_SERVICE_CSB_GOOGLE_STORAGE_BUCKET_PLANS"
 	plansPostgreSQL    = `[{"name":"small","id":"5b45de36-cb90-11ec-a755-77f8be95a49d","description":"PostgreSQL with default version, shared CPU, minimum 0.6GB ram, 10GB storage","metadata":{"displayName":"small"},"tier":"db-f1-micro","storage_gb":10},{"name":"medium","id":"a3359fa6-cb90-11ec-bcb6-cb68544eda78","description":"PostgreSQL with default version, shared CPU, minimum 1.7GB ram, 20GB storage","metadata":{"displayName":"medium"},"tier":"db-g1-small","storage_gb":20},{"name":"large","id":"cd95c5b4-cb90-11ec-a5da-df87b7fb7426","description":"PostgreSQL with default version, minimum 8 cores, minimum 8GB ram, 50GB storage","metadata":{"displayName":"large"},"tier":"db-custom-8-8192","storage_gb":50}]`
 	plansMySQL         = `[{"name":"default","id":"eec62c9b-b25e-4e65-bad5-6b74d90274bf","description":"Default MySQL v8.0 10GB storage","metadata":{"displayName":"default"},"mysql_version":"MYSQL_8_0","storage_gb":10,"tier":"db-n1-standard-2"}]`
-	plansStorage       = `[{"name": "default","id": "2875f0f0-a69f-4fe6-a5ec-5ed7f6e89a01","description": "Cloud Storage Bucket service with default configuration","metadata":{"display_name": "default"}}]`
 	oldPlansStorage    = `[{"name": "private","id": "bbc4853e-8a63-11ea-a54e-670ca63cee0b","description": "Private Storage bucket", "region": "us-central1", "storage_class": "STANDARD"},{"name": "public-read","id": "c07f21a6-8a63-11ea-bc1b-d38b123189cb","description": "Public-read Storage bucket", "region": "us-central1", "storage_class": "STANDARD"}]`
 )
 
@@ -52,9 +51,6 @@ func (b Broker) env() []apps.EnvVar {
 		apps.EnvVar{Name: "ENCRYPTION_PASSWORDS", Value: b.secrets},
 		apps.EnvVar{Name: "BROKERPAK_UPDATES_ENABLED", Value: true},
 		apps.EnvVar{Name: "TERRAFORM_UPGRADES_ENABLED", Value: true},
-		apps.EnvVar{Name: plansPostgreSQLVar, Value: plansPostgreSQL},
-		apps.EnvVar{Name: PlansMySQLVar, Value: plansMySQL},
-		apps.EnvVar{Name: plansStorageVar, Value: plansStorage},
 	)
 
 	return append(result, b.envExtras...)

--- a/acceptance-tests/postgresql_test.go
+++ b/acceptance-tests/postgresql_test.go
@@ -19,6 +19,7 @@ var _ = Describe("PostgreSQL", func() {
 		By("creating a service broker with Beta services disabled")
 		broker := brokers.Create(
 			brokers.WithPrefix("csb-postgresql"),
+			brokers.WithLatestEnv(),
 			brokers.WithEnv(apps.EnvVar{Name: "GSB_COMPATIBILITY_ENABLE_BETA_SERVICES", Value: "false"}),
 		)
 		defer broker.Delete()

--- a/acceptance-tests/withoutcredhub_test.go
+++ b/acceptance-tests/withoutcredhub_test.go
@@ -15,6 +15,7 @@ var _ = Describe("Without CredHub", Label("withoutcredhub"), func() {
 	It("can be accessed by an app", func() {
 		broker := brokers.Create(
 			brokers.WithPrefix("csb-no-credhub"),
+			brokers.WithLatestEnv(),
 			brokers.WithEnv(apps.EnvVar{Name: "CH_CRED_HUB_URL", Value: ""}),
 		)
 		defer broker.Delete()


### PR DESCRIPTION
When pushing a broker for a test, you now have to explicitly choose whether you want the env for the latest released, or for latest development.

We were getting errors for duplicate plan GUIDs when service GUIDs changed:
```
Plan ids must be unique. Unable to register plan with id 'eec62c9b-b25e-4e65-bad5-6b74d90274bf' (plan name 'default', service name 'csb-google-mysql') because it uses the same id as an existing plan (plan name 'default', service name 'csb-google-mysql', broker name 'csb-storage-alder-slicer')
```
