### PR TITLE
fix: [Postgres] remove explicit grant from acceptance_tests

### DIFF
--- a/acceptance-tests/apps/postgresqlapp/internal/app/create_schema.go
+++ b/acceptance-tests/apps/postgresqlapp/internal/app/create_schema.go
@@ -35,12 +35,6 @@ func handleCreateSchema(db *sql.DB) func(w http.ResponseWriter, r *http.Request)
 			return
 		}
 
-		_, err = db.Exec(fmt.Sprintf(`GRANT ALL ON TABLE %s.%s TO PUBLIC`, schema, tableName))
-		if err != nil {
-			fail(w, http.StatusBadRequest, "Error granting table permissions: %s", err)
-			return
-		}
-
 		w.WriteHeader(http.StatusCreated)
 		log.Printf("Schema %q created", schema)
 	}


### PR DESCRIPTION
[#185431677]

Although granting permissions to a specific table might be a perfectly valid operation for an app to do, having it in our tests might be hiding some permissions issues related to: dataOwnerUser, binding creation, etc.

### Checklist:

* ~~[ ] Have you added Release Notes in the docs repositories?~~
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

