### PR TITLE
fix: [Postgres] expose bug so we can debug it and fix it

### DIFF
--- a/acceptance-tests/postgresql_test.go
+++ b/acceptance-tests/postgresql_test.go
@@ -33,12 +33,11 @@ var _ = Describe("PostgreSQL", func() {
 		appTwo := apps.Push(apps.WithApp(apps.PostgreSQL))
 		defer apps.Delete(appOne, appTwo)
 
-		By("binding the apps to the service instance")
+		By("binding the first app to the service instance")
 		binding := serviceInstance.Bind(appOne)
-		serviceInstance.Bind(appTwo)
 
-		By("starting the apps")
-		apps.Start(appOne, appTwo)
+		By("starting the first app")
+		apps.Start(appOne)
 
 		By("checking that the app environment has a credhub reference for credentials")
 		Expect(binding.Credential()).To(matchers.HaveCredHubRef)
@@ -51,6 +50,12 @@ var _ = Describe("PostgreSQL", func() {
 		key := random.Hexadecimal()
 		value := random.Hexadecimal()
 		appOne.PUT(value, "%s/%s", schema, key)
+
+		By("binding the second app to the service instance")
+		serviceInstance.Bind(appTwo)
+
+		By("starting the second app")
+		apps.Start(appTwo)
 
 		By("getting the value using the second app")
 		got := appTwo.GET("%s/%s", schema, key).String()


### PR DESCRIPTION
[#185431677]

Binding operations of GCP can fail if a previous binding has created objects in the PUBLIC schema.

Several factors converged making it unnoticeable to our CI:
- Apps GRANTed permission to the table to PUBLIC
- Tests created all bindings before creating any db object

This commit exposes the bug by delaying the creation of the second binding until the first app creates some tables.

### Checklist:

* ~~[ ] Have you added Release Notes in the docs repositories?~~
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

