### PR TITLE
fix: [CI] build-broker-brokerpak masking errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -134,7 +134,7 @@ validate: build ## use the CSB to validate the buildpak
 # fetching bits for cf push broker
 .PHONY: cloud-service-broker
 cloud-service-broker: go.mod ## build or fetch CSB binary
-	$(shell "$(GET_CSB)")
+	"$(GET_CSB)"
 
 APP_NAME := $(or $(APP_NAME), cloud-service-broker-gcp)
 DB_TLS := $(or $(DB_TLS), skip-verify)


### PR DESCRIPTION
[#185955999](https://www.pivotaltracker.com/story/show/185955999)

shell instruction will mask any error happening in GET_CSB command such as errors resolving dependencies due to some network issue

### Checklist:

* ~~[ ] Have you added Release Notes in the docs repositories?~~
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

