### PR TITLE
chore: avoid pushing the broker in acceptance tests unnecessarily

### DIFF
--- a/acceptance-tests/postgresql_test.go
+++ b/acceptance-tests/postgresql_test.go
@@ -1,7 +1,6 @@
 package acceptance_test
 
 import (
-	"csbbrokerpakgcp/acceptance-tests/helpers/brokers"
 	"csbbrokerpakgcp/acceptance-tests/helpers/matchers"
 	"csbbrokerpakgcp/acceptance-tests/helpers/random"
 	"net"
@@ -16,20 +15,9 @@ import (
 
 var _ = Describe("PostgreSQL", func() {
 	Describe("Can be accessed by an app", func() {
-		var broker *brokers.Broker
-
-		BeforeEach(func() {
-			broker = brokers.Create(
-				brokers.WithPrefix("csb-postgresql"),
-				brokers.WithLatestEnv(),
-				brokers.WithEnv(apps.EnvVar{Name: "GSB_COMPATIBILITY_ENABLE_BETA_SERVICES", Value: "false"}),
-			)
-			defer broker.Delete()
-		})
-
 		It("works with the default postgres version", Label("postgresql"), func() {
 			By("creating a service instance")
-			serviceInstance := services.CreateInstance("csb-google-postgres", "small", services.WithBroker(broker))
+			serviceInstance := services.CreateInstance("csb-google-postgres", "small")
 			defer serviceInstance.Delete()
 
 			postgresTestMultipleApps(serviceInstance)
@@ -38,7 +26,7 @@ var _ = Describe("PostgreSQL", func() {
 
 		It("works with latest changes to public schema in postgres 15", Label("Postgres15"), func() {
 			By("creating a service instance")
-			serviceInstance := services.CreateInstance("csb-google-postgres", "pg15", services.WithBroker(broker))
+			serviceInstance := services.CreateInstance("csb-google-postgres", "pg15")
 			defer serviceInstance.Delete()
 
 			postgresTestMultipleApps(serviceInstance)


### PR DESCRIPTION
When we started GAing services our approach was to test GAed services with the ENABLE_BETA_SERVICE_OFFERINGS flag to false. In this way we could also test that the GAed service would be always available. We haven't replicated this kind of approach for other services so this now is not consistent with the rest of the tests. It would be better to just have a dedicated test for the catalog to double check this behavior than to slow down our tests and consume extra resources by pushing yet another broker

[#186011659](https://www.pivotaltracker.com/story/show/186011659)

### Checklist:

* [ ] Have you added Release Notes in the docs repositories?
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

