### PR TITLE
feat: allow specifying a custom role for each binding

### DIFF
--- a/google-postgresql.yml
+++ b/google-postgresql.yml
@@ -26,6 +26,16 @@ plan_updateable: true
 provision:
   plan_inputs: []
   user_inputs:
+  - field_name: enable_custom_roles
+    type: boolean
+    default: false
+    details: Whether to enable custom roles functionality
+    prohibit_update: true
+  - field_name: custom_roles
+    type: string
+    default: '{ "*": "binding_user_group" }'
+    details: A key-value map to specify for a given app guid (key) which role (value) to apply to new users when binding
+    prohibit_update: true
   - field_name: tier
     required: true
     type: string
@@ -145,6 +155,12 @@ provision:
     variables: terraform/cloudsql/postgresql/provision/variables.tf
     outputs: terraform/cloudsql/postgresql/provision/outputs.tf
   outputs:
+  - field_name: enable_custom_roles
+    type: boolean
+    details: Whether to enable custom roles functionality
+  - field_name: custom_roles
+    type: string
+    details: A key-value map to specify for a given app guid (key) which role (value) to apply to new users when binding
   - field_name: name
     type: string
     details: The name of the database.
@@ -176,6 +192,18 @@ bind:
   plan_inputs: []
   user_inputs: []
   computed_inputs:
+  - name: app_guid
+    type: string
+    default: ${request.app_guid}
+    overwrite: true
+  - name: enable_custom_roles
+    type: boolean
+    default: ${instance.details["enable_custom_roles"]}
+    overwrite: true
+  - name: custom_roles
+    type: string
+    default: ${instance.details["custom_roles"]}
+    overwrite: true
   - name: db_name
     type: string
     default: ${instance.details["name"]}
@@ -216,6 +244,7 @@ bind:
     provider: terraform/cloudsql/postgresql/bind/provider.tf
     versions: terraform/cloudsql/postgresql/bind/versions.tf
     main: terraform/cloudsql/postgresql/bind/main.tf
+    data: terraform/cloudsql/postgresql/bind/data.tf
     variables: terraform/cloudsql/postgresql/bind/variables.tf
     outputs: terraform/cloudsql/postgresql/bind/outputs.tf
   outputs:

--- a/integration-tests/postgres_test.go
+++ b/integration-tests/postgres_test.go
@@ -258,6 +258,8 @@ var _ = Describe("postgres", Label("postgres"), func() {
 				{Name: "sslcert", Type: "string", Value: fakeClientCert},
 				{Name: "sslkey", Type: "string", Value: fakeClientKey},
 				{Name: "private_ip", Type: "string", Value: fakePrivateIP},
+				{Name: "enable_custom_roles", Type: "bool", Value: false},
+				{Name: "custom_roles", Type: "string", Value: ""},
 			})
 			Expect(err).NotTo(HaveOccurred())
 
@@ -286,6 +288,9 @@ var _ = Describe("postgres", Label("postgres"), func() {
 				"sslcert":     fakeClientCert,
 				"sslkey":      fakeClientKey,
 				"private_ip":  fakePrivateIP,
+
+				"enable_custom_roles": false,
+				"custom_roles":        "",
 			}))
 		})
 	})

--- a/terraform/cloudsql/postgresql/bind/data.tf
+++ b/terraform/cloudsql/postgresql/bind/data.tf
@@ -1,0 +1,5 @@
+locals {
+  roles_map    = jsondecode(var.custom_roles)
+  custom_roles = try(local.roles_map[var.app_guid], local.roles_map["*"], "binding_user_group")
+  actual_roles = var.enable_custom_roles ? local.custom_roles : "binding_user_group"
+}

--- a/terraform/cloudsql/postgresql/bind/provider.tf
+++ b/terraform/cloudsql/postgresql/bind/provider.tf
@@ -4,7 +4,7 @@ provider "csbpg" {
   username        = var.admin_username
   password        = var.admin_password
   database        = var.db_name
-  data_owner_role = "binding_user_group"
+  data_owner_role = local.actual_roles
   sslmode         = "verify-ca"
   sslrootcert     = var.sslrootcert
   clientcert {

--- a/terraform/cloudsql/postgresql/bind/variables.tf
+++ b/terraform/cloudsql/postgresql/bind/variables.tf
@@ -17,3 +17,7 @@ variable "sslrootcert" { type = string }
 locals {
   port = 5432
 }
+
+variable "enable_custom_roles" { type = bool }
+variable "custom_roles" { type = string }
+variable "app_guid" { type = string }

--- a/terraform/cloudsql/postgresql/provision/outputs.tf
+++ b/terraform/cloudsql/postgresql/provision/outputs.tf
@@ -16,3 +16,5 @@ output "sslkey" {
 }
 output "sslrootcert" { value = google_sql_database_instance.instance.server_ca_cert.0.cert }
 
+output "enable_custom_roles" { value = var.enable_custom_roles }
+output "custom_roles" { value = var.custom_roles }

--- a/terraform/cloudsql/postgresql/provision/variables.tf
+++ b/terraform/cloudsql/postgresql/provision/variables.tf
@@ -21,3 +21,6 @@ variable "credentials" {
 }
 variable "project" { type = string }
 variable "require_ssl" { type = bool }
+
+variable "enable_custom_roles" { type = bool }
+variable "custom_roles" { type = string }


### PR DESCRIPTION
[#184596268](https://www.pivotaltracker.com/story/show/184596268)

This is a prototype. I'm open to constructive criticism and suggestions.
The main goals of this prototype are:
- Introduce as few changes as possible
- Relieve csb developers from having to deal with roles/permissions/ownership
- Don't impose any roles/permissions/ownership to owners of the database
- Don't step on the way of db admins who want to architect their db security and permissions
- When possible, make it easy for db admins to use a relaxed permission model (all bindings have equal permissions)
- Be 100% backward compatible with existing instances

### Checklist:

* [ ] Have you added Release Notes in the docs repositories?
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

