### PR TITLE
chore: run Dependabot daily

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,48 +3,45 @@ updates:
 - package-ecosystem: gomod
   directory: "/"
   schedule:
-    interval: "weekly"
-    day: "saturday"
-    time: "06:00"
+    interval: "daily"
+    time: "22:00"
 - package-ecosystem: gomod
   directory: "/acceptance-tests/apps/dataprocapp"
   schedule:
-    interval: "weekly"
-    day: "saturday"
-    time: "06:00"
+    interval: "daily"
+    time: "22:00"
 - package-ecosystem: gomod
   directory: "/acceptance-tests/apps/mysqlapp"
   schedule:
-    interval: "weekly"
-    day: "saturday"
-    time: "06:00"
+    interval: "daily"
+    time: "22:00"
 - package-ecosystem: gomod
   directory: "/acceptance-tests/apps/postgresqlapp"
   schedule:
-    interval: "weekly"
-    day: "saturday"
-    time: "06:00"
+    interval: "daily"
+    time: "22:00"
 - package-ecosystem: gomod
   directory: "/acceptance-tests/apps/redisapp"
   schedule:
-    interval: "weekly"
-    day: "saturday"
-    time: "06:00"
+    interval: "daily"
+    time: "22:00"
 - package-ecosystem: gomod
   directory: "/acceptance-tests/apps/spannerapp"
   schedule:
-    interval: "weekly"
-    day: "saturday"
-    time: "06:00"
+    interval: "daily"
+    time: "22:00"
 - package-ecosystem: gomod
   directory: "/acceptance-tests/apps/storageapp"
   schedule:
-    interval: "weekly"
-    day: "saturday"
-    time: "06:00"    
+    interval: "daily"
+    time: "22:00"
 - package-ecosystem: npm
   directory: "/acceptance-tests/apps/stackdrivertraceapp"
   schedule:
-    interval: "weekly"
-    day: "saturday"
-    time: "06:00"
+    interval: "daily"
+    time: "22:00"
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: "daily"
+    time: "22:00"


### PR DESCRIPTION
This will result in more PRs, but it will bring us close to always being ready to release.