### PR TITLE
feat: restrict upgrade to v1.3 only

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -9,29 +9,15 @@ platforms:
 # - os: darwin
 #   arch: amd64
 terraform_upgrade_path:
-  - version: 1.2.4
-  - version: 1.3.9
-  - version: 1.5.7
+- version: 1.5.7
 terraform_binaries:
 - name: terraform
   version: 1.5.7
   source: https://github.com/hashicorp/terraform/archive/v1.5.7.zip
   default: true
-- name: terraform
-  version: 1.3.9
-  source: https://github.com/hashicorp/terraform/archive/v1.3.9.zip
-- name: terraform
-  version: 1.2.4
-  source: https://github.com/hashicorp/terraform/archive/v1.2.4.zip
 - name: terraform-provider-google
   version: 4.84.0
   source: https://github.com/terraform-providers/terraform-provider-google/archive/v4.84.0.zip
-- name: terraform-provider-local
-  version: 2.4.0
-  source: https://github.com/terraform-providers/terraform-provider-local/archive/v2.4.0.zip
-- name: terraform-provider-mysql
-  version: 1.9.0
-  source: https://github.com/terraform-providers/terraform-provider-mysql/archive/v1.9.0.zip
 - name: terraform-provider-random
   version: 3.6.0
   source: https://github.com/terraform-providers/terraform-provider-random/archive/v3.6.0.zip


### PR DESCRIPTION
In order to reduce the size of the brokerpak, obsolete Terraform providers have been removed. As a result, to get to this version through upgrading, you must upgrade to v1.3 first and upgrade all service instances to v1.3. This can be done via "cf upgrade-service", or for bulk upgrades consider the plugin: https://github.com/cloudfoundry/upgrade-all-services-cli-plugin You can then upgrade to this version, and again upgrade all the service instances.

[#186588913](https://www.pivotaltracker.com/story/show/186588913)
