### PR TITLE
chore: remove run-in-docker logic from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,16 +12,11 @@ GO-VER = go$(GO-VERSION)
 CSB_VERSION := $(or $(CSB_VERSION), $(shell grep 'github.com/cloudfoundry/cloud-service-broker' go.mod | grep -v replace | awk '{print $$NF}' | sed -e 's/v//'))
 CSB_RELEASE_VERSION := $(CSB_VERSION)
 
-CSB_DOCKER_IMAGE := $(or $(CSB), cfplatformeng/csb:$(CSB_VERSION))
-GO_OK :=  $(or $(USE_GO_CONTAINERS), $(shell which go 1>/dev/null 2>/dev/null; echo $$?))
-DOCKER_OK := $(shell which docker 1>/dev/null 2>/dev/null; echo $$?)
-
 ####### broker environment variables
 SECURITY_USER_NAME := $(or $(SECURITY_USER_NAME), gcp-broker)
 SECURITY_USER_PASSWORD := $(or $(SECURITY_USER_PASSWORD), gcp-broker-pw)
 GSB_PROVISION_DEFAULTS := $(or $(GSB_PROVISION_DEFAULTS), {"authorized_network_id": "https://www.googleapis.com/compute/v1/projects/$GOOGLE_PROJECT/global/networks/$GCP_PAS_NETWORK"})
 
-ifeq ($(GO_OK), 0) # use local go binary
 GO=go
 GOFMT=gofmt
 BROKER_GO_OPTS=PORT=8080 \
@@ -43,38 +38,6 @@ PAK_PATH=$(PWD) #where the brokerpak zip resides
 RUN_CSB=$(BROKER_GO_OPTS) go run github.com/cloudfoundry/cloud-service-broker
 LDFLAGS="-X github.com/cloudfoundry/cloud-service-broker/utils.Version=$(CSB_VERSION)"
 GET_CSB="env CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags $(LDFLAGS) github.com/cloudfoundry/cloud-service-broker"
-else ifeq ($(DOCKER_OK), 0) ## running the broker and go with docker
-BROKER_DOCKER_OPTS=--rm -v $(PAK_BUILD_CACHE_PATH):$(PAK_BUILD_CACHE_PATH) -v $(PWD):/brokerpak -w /brokerpak --network=host \
-  -p 8080:8080 \
-	-e SECURITY_USER_NAME \
-	-e SECURITY_USER_PASSWORD \
-	-e GOOGLE_CREDENTIALS \
-	-e GOOGLE_PROJECT \
-	-e "DB_TYPE=sqlite3" \
-	-e "DB_PATH=/tmp/csb-db" \
-	-e PAK_BUILD_CACHE_PATH=$(PAK_BUILD_CACHE_PATH) \
-	-e GSB_PROVISION_DEFAULTS \
-	-e GSB_SERVICE_CSB_GOOGLE_POSTGRES_PLANS \
-	-e GSB_SERVICE_CSB_GOOGLE_MYSQL_PLANS \
-	-e GSB_SERVICE_CSB_GOOGLE_STORAGE_BUCKET_PLANS \
-	-e GSB_SERVICE_CSB_GOOGLE_REDIS_PLANS \
-	-e GSB_COMPATIBILITY_ENABLE_BETA_SERVICES
-
-RUN_CSB=docker run $(BROKER_DOCKER_OPTS) $(CSB_DOCKER_IMAGE)
-
-#### running go inside a container, this is for integration tests and push-broker
-# path inside the container
-PAK_PATH=/brokerpak
-
-GO_DOCKER_OPTS=--rm -v $(PAK_BUILD_CACHE_PATH):$(PAK_BUILD_CACHE_PATH) -v $(PWD):/brokerpak -w /brokerpak --network=host
-GO=docker run $(GO_DOCKER_OPTS) golang:latest go
-GOFMT=docker run $(GO_DOCKER_OPTS) golang:latest gofmt
-
-# this doesnt work well if we did make latest-csb. We should build it instead, with go inside a container.
-GET_CSB="wget -O cloud-service-broker https://github.com/cloudfoundry/cloud-service-broker/releases/download/v$(CSB_RELEASE_VERSION)/cloud-service-broker.linux && chmod +x cloud-service-broker"
-else
-$(error either Go or Docker must be installed)
-endif
 
 ###### Targets ################################################################
 

--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,6 @@ SECURITY_USER_NAME := $(or $(SECURITY_USER_NAME), gcp-broker)
 SECURITY_USER_PASSWORD := $(or $(SECURITY_USER_PASSWORD), gcp-broker-pw)
 GSB_PROVISION_DEFAULTS := $(or $(GSB_PROVISION_DEFAULTS), {"authorized_network_id": "https://www.googleapis.com/compute/v1/projects/$GOOGLE_PROJECT/global/networks/$GCP_PAS_NETWORK"})
 
-GO=go
-GOFMT=gofmt
 BROKER_GO_OPTS=PORT=8080 \
 				DB_TYPE=sqlite3 \
 				DB_PATH=/tmp/csb-db \
@@ -44,8 +42,8 @@ GET_CSB="env CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags $(LDFLAGS) 
 .PHONY: deps-go-binary
 deps-go-binary:
 ifeq ($(SKIP_GO_VERSION_CHECK),)
-	@@if [ "$$($(GO) version | awk '{print $$3}')" != "${GO-VER}" ]; then \
-		echo "Go version does not match: expected: ${GO-VER}, got $$($(GO) version | awk '{print $$3}')"; \
+	@@if [ "$$(go version | awk '{print $$3}')" != "${GO-VER}" ]; then \
+		echo "Go version does not match: expected: ${GO-VER}, got $$(go version | awk '{print $$3}')"; \
 		exit 1; \
 	fi
 endif
@@ -137,13 +135,13 @@ $(PAK_BUILD_CACHE_PATH):
 	
 .PHONY: latest-csb
 latest-csb: ## point to the very latest CSB on GitHub
-	$(GO) get -d github.com/cloudfoundry/cloud-service-broker@main
-	$(GO) mod tidy
+	go get -d github.com/cloudfoundry/cloud-service-broker@main
+	go mod tidy
 
 .PHONY: local-csb
 local-csb: ## point to a local CSB repo
 	echo "replace \"github.com/cloudfoundry/cloud-service-broker\" => \"$$PWD/../cloud-service-broker\"" >>go.mod
-	$(GO) mod tidy
+	go mod tidy
 
 .PHONY: lint
 lint: checkgoformat checkgoimports checktfformat vet staticcheck ## checks format, imports and vet
@@ -155,26 +153,26 @@ checktfformat: ## checks that Terraform HCL is formatted correctly
 	fi
 
 checkgoformat: ## checks that the Go code is formatted correctly
-	@@if [ -n "$$(${GOFMT} -s -e -l -d .)" ]; then       \
+	@@if [ -n "$$(gofmt -s -e -l -d .)" ]; then       \
 		echo "gofmt check failed: run 'make format'"; \
 		exit 1;                                       \
 	fi
 
 checkgoimports: ## checks that Go imports are formatted correctly
-	@@if [ -n "$$(${GO} run golang.org/x/tools/cmd/goimports -l -d .)" ]; then \
+	@@if [ -n "$$(go run golang.org/x/tools/cmd/goimports -l -d .)" ]; then \
 		echo "goimports check failed: run 'make format'";                      \
 		exit 1;                                                                \
 	fi
 
 vet: ## Runs go vet
-	${GO} vet ./...
+	go vet ./...
 
 staticcheck: ## Runs staticcheck
-	${GO} run honnef.co/go/tools/cmd/staticcheck ./...
+	go run honnef.co/go/tools/cmd/staticcheck ./...
 
 .PHONY: format
 format: ## format the source
-	${GOFMT} -s -e -l -w .
-	${GO} run golang.org/x/tools/cmd/goimports -l -w .
+	gofmt -s -e -l -w .
+	go run golang.org/x/tools/cmd/goimports -l -w .
 	terraform fmt --recursive
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Available make targets can be listed by running `make`.
 2. Launch an interactive shell into some supported image containing all necessary tools. For example:
    ```
    # From the root of this repo run:
-   docker run -it --rm -v "${PWD}:/repo" --workdir "/repo" --entrypoint "/bin/bash" cflondonservices/csb-ci-main
+   docker run -it --rm -v "${PWD}:/repo" --workdir "/repo" --entrypoint "/bin/bash" golang:latest
    make
    ```
 

--- a/README.md
+++ b/README.md
@@ -4,10 +4,8 @@ A brokerpak for the [Cloud Service Broker](https://github.com/pivotal/cloud-serv
 
 ## Development Requirements
 
-* Either Go 1.18 or [Docker](https://docs.docker.com/get-docker/)
+* Either an up-to-date version of Go or [Docker](https://docs.docker.com/get-docker/)
 * make - covers development lifecycle steps
-
-A docker container for the cloud service broker binary is available at *cfplatformeng/csb*
 
 ## GCP account information
 
@@ -27,14 +25,16 @@ Available make targets can be listed by running `make`.
 ### Running with docker
 
 1. Install [Docker](https://docs.docker.com/get-docker/)
-2. If you don't have Go installed, the makefile will automatically use Docker. If you do have go installed but still want to use docker, then set the `USE_GO_CONTAINERS` to `true`.
-
-Make targets will run with the *cfplatformeng/csb* docker image. Alternatively, a custom image can be specified by setting the `CSB` environment variable.
+2. Launch an interactive shell into some supported image containing all necessary tools. For example:
+   ```
+   # From the root of this repo run:
+   docker run -it --rm -v "${PWD}:/repo" --workdir "/repo" --entrypoint "/bin/bash" cflondonservices/csb-ci-main
+   make
+   ```
 
 ### Running with Go
 
 1. Make sure you have the right Go version installed (see `go.mod` file).
-2. Make sure `USE_GO_CONTAINERS` environment variable is ***NOT*** set.
 
 The make targets will build the source using the local go installation.
 


### PR DESCRIPTION
The same benefits can be achieved by simply launching an interactive docker session inside a supported image and running commands from there. This approach has some additional benefits
- Easier to maintain
- Debloats Makefile
- Less hidden magic
- Same code for local and containerised execution

### Checklist:

* [ ] Have you added Release Notes in the docs repositories?
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

