### PR TITLE
chore: specify go 1.22.0 in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module csbbrokerpakgcp
 
-go 1.22
+go 1.22.0
 
 require (
 	cloud.google.com/go/trace v1.10.5


### PR DESCRIPTION
Related PRs:
- https://github.com/cloudfoundry/csb-brokerpak-gcp/pull/1044

### Checklist:

* [ ] Have you added Release Notes in the docs repositories?
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

