### PR TITLE
chore: annotate sensitive terraform varaibles

### DIFF
--- a/terraform/bigquery/bind/variables.tf
+++ b/terraform/bigquery/bind/variables.tf
@@ -3,4 +3,7 @@ variable "role" { type = string }
 variable "service_account_name" { type = string }
 variable "service_account_display_name" { type = string }
 variable "project" { type = string }
-variable "credentials" { type = string }
+variable "credentials" {
+  type      = string
+  sensitive = true
+}

--- a/terraform/bigquery/provision/variables.tf
+++ b/terraform/bigquery/provision/variables.tf
@@ -1,4 +1,7 @@
-variable "credentials" { type = string }
+variable "credentials" {
+  type      = string
+  sensitive = true
+}
 variable "project" { type = string }
 variable "labels" { type = map(any) }
 variable "region" { type = string }

--- a/terraform/dataproc/provision/variables.tf
+++ b/terraform/dataproc/provision/variables.tf
@@ -8,5 +8,8 @@ variable "name" { type = string }
 variable "region" { type = string }
 variable "labels" { type = map(any) }
 
-variable "credentials" { type = string }
+variable "credentials" {
+  type      = string
+  sensitive = true
+}
 variable "project" { type = string }

--- a/terraform/redis/provision/variables.tf
+++ b/terraform/redis/provision/variables.tf
@@ -6,6 +6,9 @@ variable "instance_id" { type = string }
 variable "region" { type = string }
 variable "memory_size_gb" { type = number }
 variable "labels" { type = map(any) }
-variable "credentials" { type = string }
+variable "credentials" {
+  type      = string
+  sensitive = true
+}
 variable "project" { type = string }
 variable "reserved_ip_range" { type = string }

--- a/terraform/spanner/provision/variables.tf
+++ b/terraform/spanner/provision/variables.tf
@@ -1,4 +1,7 @@
-variable "credentials" { type = string }
+variable "credentials" {
+  type      = string
+  sensitive = true
+}
 variable "project" { type = string }
 variable "labels" { type = map(any) }
 variable "ddl" { type = list(any) }

--- a/terraform/stackdriver/bind/variables.tf
+++ b/terraform/stackdriver/bind/variables.tf
@@ -1,4 +1,7 @@
 variable "name" { type = string }
-variable "credentials" { type = string }
+variable "credentials" {
+  type      = string
+  sensitive = true
+}
 variable "project" { type = string }
 variable "role" { type = string }

--- a/terraform/storage/bind/variables.tf
+++ b/terraform/storage/bind/variables.tf
@@ -1,4 +1,7 @@
-variable "credentials" { type = string }
+variable "credentials" {
+  type      = string
+  sensitive = true
+}
 variable "project" { type = string }
 variable "role" { type = string }
 variable "service_account_name" { type = string }

--- a/terraform/storage/provision/variables.tf
+++ b/terraform/storage/provision/variables.tf
@@ -2,7 +2,10 @@ variable "name" { type = string }
 variable "region" { type = string }
 variable "storage_class" { type = string }
 variable "labels" { type = map(any) }
-variable "credentials" { type = string }
+variable "credentials" {
+  type      = string
+  sensitive = true
+}
 variable "project" { type = string }
 variable "placement_dual_region_data_locations" { type = list(string) }
 variable "versioning" { type = bool }


### PR DESCRIPTION
By annotating terraform variables that contain sensitive information, we ensure that they are not printed out in error messages.

Note that we have not chosen to annotate IDs (e.g. project ID) as sensitive, but only credentials. This is because printing out an ID in an error message can be very helpful.

[#183474488](https://www.pivotaltracker.com/story/show/183474488)