### PR TITLE
chore: add GitHub action PR check for focused tests

### DIFF
--- a/.github/workflows/focused-test.yml
+++ b/.github/workflows/focused-test.yml
@@ -1,0 +1,14 @@
+name: Focused Test
+
+on: [pull_request]
+
+jobs:
+  focused-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.22.1'
+      - uses: actions/checkout@v4
+      - run: go run github.com/onsi/ginkgo/v2/ginkgo unfocus && test -z "$(git status -s)"
+


### PR DESCRIPTION
Sometimes we accidentally commit a change which focuses a test. This check should highlight the problem before we merge a PR.

[#187240999](https://www.pivotaltracker.com/story/show/187240999)
