### PR TITLE
test: remove Chi dependency from test app

### DIFF
--- a/acceptance-tests/apps/postgresqlapp/go.mod
+++ b/acceptance-tests/apps/postgresqlapp/go.mod
@@ -4,7 +4,6 @@ go 1.22.2
 
 require (
 	github.com/cloudfoundry-community/go-cfenv v1.18.0
-	github.com/go-chi/chi/v5 v5.0.12
 	github.com/jackc/pgx/v5 v5.5.5
 	github.com/mitchellh/mapstructure v1.5.0
 )

--- a/acceptance-tests/apps/postgresqlapp/go.sum
+++ b/acceptance-tests/apps/postgresqlapp/go.sum
@@ -4,8 +4,6 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
-github.com/go-chi/chi/v5 v5.0.12 h1:9euLV5sTrTNTRUU9POmDUvfxyj6LAABLUcEWO+JJb4s=
-github.com/go-chi/chi/v5 v5.0.12/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNITLSKoi8=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=

--- a/acceptance-tests/apps/postgresqlapp/internal/app/get.go
+++ b/acceptance-tests/apps/postgresqlapp/internal/app/get.go
@@ -5,15 +5,13 @@ import (
 	"fmt"
 	"log"
 	"net/http"
-
-	"github.com/go-chi/chi/v5"
 )
 
 func handleGet(db *sql.DB) func(w http.ResponseWriter, r *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 		log.Println("Handling get.")
 
-		key := chi.URLParam(r, "key")
+		key := r.PathValue("key")
 		if key == "" {
 			fail(w, http.StatusBadRequest, "key missing or zero length")
 			return

--- a/acceptance-tests/apps/postgresqlapp/internal/app/set.go
+++ b/acceptance-tests/apps/postgresqlapp/internal/app/set.go
@@ -6,15 +6,13 @@ import (
 	"io"
 	"log"
 	"net/http"
-
-	"github.com/go-chi/chi/v5"
 )
 
 func handleSet(db *sql.DB) func(w http.ResponseWriter, r *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 		log.Println("Handling set.")
 
-		key := chi.URLParam(r, "key")
+		key := r.PathValue("key")
 		if key == "" {
 			fail(w, http.StatusBadRequest, "key missing or zero length")
 			return


### PR DESCRIPTION
Go 1.22 has an improved HTTP router that means we don't need the Chi router any more.

[#187470327](https://www.pivotaltracker.com/story/show/187470327)