### PR TITLE
test: http method correction for PostgreSQL app

### DIFF
--- a/acceptance-tests/apps/postgresqlapp/internal/app/app.go
+++ b/acceptance-tests/apps/postgresqlapp/internal/app/app.go
@@ -24,7 +24,7 @@ func App(uri string) http.Handler {
 	log.Printf("Connection succeeded")
 
 	r := http.NewServeMux()
-	r.HandleFunc("HEAD /", aliveness)
+	r.HandleFunc("GET /", aliveness)
 	r.HandleFunc("PUT /{schema}", handleCreateSchema(db))
 	r.HandleFunc("DELETE /{schema}", handleDropSchema(db))
 


### PR DESCRIPTION
Fixes error:
```
panic: pattern "GET /{schema}/{key}" (registered at /tmp/build/5af53159/brokerpak/acceptance-tests/apps/postgresqlapp/internal/app/app.go:34) conflicts with pattern "HEAD /" (registered at /tmp/build/5af53159/brokerpak/acceptance-tests/apps/postgresqlapp/internal/app/app.go:27):
GET /{schema}/{key} matches more methods than HEAD /, but has a more specific path pattern
```

[#187470327](https://www.pivotaltracker.com/story/show/187470327)
