### PR TITLE
fix: potential panic

### DIFF
--- a/acceptance-tests/apps/pubsubapp/internal/app/publish.go
+++ b/acceptance-tests/apps/pubsubapp/internal/app/publish.go
@@ -30,6 +30,7 @@ func handlePublish(w http.ResponseWriter, r *http.Request, client *pubsub.Client
 	finished.Add(1)
 
 	go func(res *pubsub.PublishResult) {
+		defer finished.Done()
 		// The Get method blocks until a server-generated ID or
 		// an error is returned for the published message.
 		id, err := res.Get(ctx)
@@ -39,7 +40,6 @@ func handlePublish(w http.ResponseWriter, r *http.Request, client *pubsub.Client
 			return
 		}
 		fmt.Fprintf(w, "Published message msg ID: %v\n", id)
-		finished.Done()
 	}(result)
 
 	w.WriteHeader(http.StatusCreated)

--- a/acceptance-tests/apps/pubsubapp/internal/app/receive.go
+++ b/acceptance-tests/apps/pubsubapp/internal/app/receive.go
@@ -19,9 +19,13 @@ func handleReceive(w http.ResponseWriter, r *http.Request, client *pubsub.Client
 	defer cancel()
 
 	err := sub.Receive(ctx, func(_ context.Context, msg *pubsub.Message) {
-		w.Write(msg.Data)
-		w.WriteHeader(http.StatusOK)
 		w.Header().Set("Content-Type", "text/html")
+		w.WriteHeader(http.StatusOK)
+		_, err := w.Write(msg.Data)
+		if err != nil {
+			log.Printf("Error writing response: %v", err)
+			return
+		}
 
 		msg.Ack()
 


### PR DESCRIPTION
- publish.go: The error from `res.Get(ctx)` is not properly handled. It's printed to the ResponseWriter, but this is done inside a goroutine, which may run after the HTTP response has already been sent, leading to a potential panic or undefined behavior.
- receive.go:  the order of operations when handling the HTTP response is incorrect.

[#187726190](https://www.pivotaltracker.com/story/show/#187726190)

### Checklist:

* [ ] Have you added Release Notes in the docs repositories?
* [ ] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

