### PR TITLE
fix: Should check for authorised network only when it being used

### DIFF
--- a/terraform/cloudsql/mysql/provision/data.tf
+++ b/terraform/cloudsql/mysql/provision/data.tf
@@ -1,9 +1,10 @@
 data "google_compute_network" "authorized-network" {
-  name = "default"
+  count = length(var.authorized_network_id) > 0 ? 0 : 1
+  name  = "default"
 }
 
 locals {
-  authorized_network_id           = length(var.authorized_network_id) > 0 ? var.authorized_network_id : data.google_compute_network.authorized-network.self_link
+  authorized_network_id           = length(var.authorized_network_id) > 0 ? var.authorized_network_id : data.google_compute_network.authorized-network[0].self_link
   transaction_log_backups_enabled = var.backups_transaction_log_retention_days > 0
   backups_enabled                 = var.backups_retain_number > 0 || local.transaction_log_backups_enabled
   availability_type               = var.highly_available ? "REGIONAL" : "ZONAL"

--- a/terraform/cloudsql/postgresql/provision/data.tf
+++ b/terraform/cloudsql/postgresql/provision/data.tf
@@ -1,9 +1,10 @@
 data "google_compute_network" "authorized-network" {
-  name = var.authorized_network
+  count = length(var.authorized_network_id) > 0 ? 0 : 1
+  name  = var.authorized_network
 }
 
 locals {
-  authorized_network_id = length(var.authorized_network_id) > 0 ? var.authorized_network_id : data.google_compute_network.authorized-network.self_link
+  authorized_network_id = length(var.authorized_network_id) > 0 ? var.authorized_network_id : data.google_compute_network.authorized-network[0].self_link
   availability_type     = var.highly_available ? "REGIONAL" : "ZONAL"
   primary_zone          = var.location_preference_zone == "" ? "" : join("-", [var.region, var.location_preference_zone])
   secondary_zone        = var.location_preference_secondary_zone == "" ? "" : join("-", [var.region, var.location_preference_secondary_zone])

--- a/terraform/redis/provision/data.tf
+++ b/terraform/redis/provision/data.tf
@@ -1,7 +1,8 @@
 data "google_compute_network" "authorized-network" {
-  name = var.authorized_network
+  count = length(var.authorized_network_id) > 0 ? 0 : 1
+  name  = var.authorized_network
 }
 
 locals {
-  authorized_network_id = length(var.authorized_network_id) > 0 ? var.authorized_network_id : data.google_compute_network.authorized-network.self_link
+  authorized_network_id = length(var.authorized_network_id) > 0 ? var.authorized_network_id : data.google_compute_network.authorized-network[0].self_link
 }


### PR DESCRIPTION
When `authorized_network_id` we do not need to check for the existence of `var.authorized_network`

[#187737556](https://www.pivotaltracker.com/story/show/183975388)

### Checklist:

* [ ] Have you added Release Notes in the docs repositories?
* [ ] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

