### PR TITLE
chore: Test dependencies are updated only once a week

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,60 +5,68 @@ updates:
   schedule:
     interval: "daily"
     time: "20:00"
+  ignore:
+    - dependency-name: "google.golang.org/api"
+    - dependency-name: "cloud.google.com/go/*"
+- package-ecosystem: gomod
+  directory: "/"
+  schedule:
+    interval: "weekly"
+    day: "saturday"
 - package-ecosystem: gomod
   directory: "/acceptance-tests/apps/dataprocapp"
   schedule:
-    interval: "daily"
-    time: "20:30"
+    interval: "weekly"
+    day: "saturday"
   labels:
     - "test-dependencies"
 - package-ecosystem: gomod
   directory: "/acceptance-tests/apps/mysqlapp"
   schedule:
-    interval: "daily"
-    time: "21:00"
+    interval: "weekly"
+    day: "saturday"
   labels:
     - "test-dependencies"
 - package-ecosystem: gomod
   directory: "/acceptance-tests/apps/postgresqlapp"
   schedule:
-    interval: "daily"
-    time: "21:30"
+    interval: "weekly"
+    day: "saturday"
   labels:
     - "test-dependencies"
 - package-ecosystem: gomod
   directory: "/acceptance-tests/apps/redisapp"
   schedule:
-    interval: "daily"
-    time: "22:00"
+    interval: "weekly"
+    day: "saturday"
   labels:
     - "test-dependencies"
 - package-ecosystem: gomod
   directory: "/acceptance-tests/apps/spannerapp"
   schedule:
-    interval: "daily"
-    time: "22:30"
+    interval: "weekly"
+    day: "saturday"
   labels:
     - "test-dependencies"
 - package-ecosystem: gomod
   directory: "/acceptance-tests/apps/storageapp"
   schedule:
-    interval: "daily"
-    time: "23:00"
+    interval: "weekly"
+    day: "saturday"
   labels:
     - "test-dependencies"
 - package-ecosystem: gomod
   directory: "/acceptance-tests/apps/pubsubapp"
   schedule:
-    interval: "daily"
-    time: "23:30"
+    interval: "weekly"
+    day: "saturday"
   labels:
     - "test-dependencies"
 - package-ecosystem: npm
   directory: "/acceptance-tests/apps/stackdrivertraceapp"
   schedule:
-    interval: "daily"
-    time: "23:30"
+    interval: "weekly"
+    day: "saturday"
   labels:
     - "test-dependencies"
 - package-ecosystem: "github-actions"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,7 @@ updates:
     - dependency-name: "cloud.google.com/go/*"
 - package-ecosystem: gomod
   directory: "/"
+  target-branch: main
   schedule:
     interval: "weekly"
     day: "saturday"


### PR DESCRIPTION
These changes are to optimise the use of the CI. Every full run through the pipeline requires several AWS environments and several hours of tests.

### Checklist:

* [ ] Have you added Release Notes in the docs repositories?
* [ ] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

