### PR TITLE
chore: add provider definitions to bindings

### DIFF
--- a/google-bigquery.yml
+++ b/google-bigquery.yml
@@ -108,6 +108,7 @@ bind:
       default: ""
       overwrite: true
   template_refs:
+    provider: terraform/bigquery/bind/provider.tf
     main: terraform/bigquery/bind/main.tf
     variables: terraform/bigquery/bind/variables.tf
     data: terraform/bigquery/bind/data.tf

--- a/google-dataproc.yml
+++ b/google-dataproc.yml
@@ -103,6 +103,7 @@ bind:
     default: ${instance.details["bucket_name"]}
     overwrite: true
   template_refs:
+    provider: terraform/dataproc/bind/provider.tf
     main: terraform/dataproc/bind/main.tf
     variables: terraform/dataproc/bind/variables.tf
     outputs: terraform/dataproc/bind/outputs.tf

--- a/google-spanner.yml
+++ b/google-spanner.yml
@@ -158,6 +158,7 @@ bind:
   template_refs:
     main: terraform/spanner/bind/main.tf
     data: terraform/spanner/bind/data.tf
+    provider: terraform/spanner/bind/provider.tf
     variables: terraform/spanner/bind/variables.tf
     outputs: terraform/spanner/bind/outputs.tf
     versions: terraform/spanner/bind/versions.tf

--- a/terraform/bigquery/bind/provider.tf
+++ b/terraform/bigquery/bind/provider.tf
@@ -1,0 +1,4 @@
+provider "google" {
+  credentials = var.credentials
+  project     = var.project
+}

--- a/terraform/dataproc/bind/provider.tf
+++ b/terraform/dataproc/bind/provider.tf
@@ -1,0 +1,4 @@
+provider "google" {
+  credentials = var.credentials
+  project     = var.project
+}

--- a/terraform/spanner/bind/provider.tf
+++ b/terraform/spanner/bind/provider.tf
@@ -1,0 +1,4 @@
+provider "google" {
+  credentials = var.credentials
+  project     = var.project
+}


### PR DESCRIPTION
it seems that implicit provider definitions require the GOOGLE_PROJECT und GOOGLE_CREDENTIALS ENV vars to work.

the tile based on kiln does not set env vars for the csb app anymore, it writes a "full" config before it pushes the app. These services currently fail when trying to create a bind because some fields on the required resources are `implicitly` sourced from the provider by open tofu.

[#187498188]

### Checklist:

* [ ] Have you added Release Notes in the docs repositories?
* [ ] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

