### PR TITLE
chore: update test to access case insensitive matches

### DIFF
--- a/terraform-tests/storage_test.go
+++ b/terraform-tests/storage_test.go
@@ -54,7 +54,7 @@ var _ = Describe("storage", Label("storage-terraform"), Ordered, func() {
 			Expect(AfterValuesForType(plan, googleBucketResource)).To(
 				MatchKeys(IgnoreExtras, Keys{
 					"name":                     Equal("bucket-name"),
-					"location":                 Equal("us"),
+					"location":                 MatchRegexp(`(?i)^us$`), //the regex matches case insensitively,
 					"storage_class":            Equal("MULTI_REGIONAL"),
 					"labels":                   MatchAllKeys(Keys{"label1": Equal("value1")}),
 					"custom_placement_config":  BeEmpty(), // TF internals: It is a []any{} which means no custom_placement_config
@@ -98,7 +98,7 @@ var _ = Describe("storage", Label("storage-terraform"), Ordered, func() {
 			Expect(AfterValuesForType(plan, googleBucketResource)).To(
 				MatchKeys(IgnoreExtras, Keys{
 					"name":          Equal("bucket-name"),
-					"location":      Equal("us"),
+					"location":      MatchRegexp(`(?i)^us$`), //the regex matches case insensitively
 					"storage_class": Equal("STANDARD"),
 					"labels":        MatchAllKeys(Keys{"label1": Equal("value1")}),
 					"custom_placement_config": ConsistOf(


### PR DESCRIPTION
we switched the "internal" string use for dual regions like `us` to
always be lowercase in our code. But the API may still return `US`.

this updates the test to not expect a case sensitive match since both
options are correct.