### PR TITLE
chore: tests broken since 2c574da4b6f4b0c72001c5131e84c3d3ce6ae460

### DIFF
--- a/google-storage.yml
+++ b/google-storage.yml
@@ -284,10 +284,10 @@ examples:
 - name: gcp-bucket-multi-region
   description: Create a Google Storage instance with multi-region configuration in USA
   plan_id: 2875f0f0-a69f-4fe6-a5ec-5ed7f6e89a01
-  provision_params: { "storage_class": "MULTI_REGIONAL", "region": "us" }
+  provision_params: { "storage_class": "MULTI_REGIONAL" }
   bind_params: { "role": "storage.objectAdmin" }
 - name: gcp-bucket-dual-region
   description: Dual Region Bucket
   plan_id: 2875f0f0-a69f-4fe6-a5ec-5ed7f6e89a01
-  provision_params: { "storage_class": "NEARLINE", "placement_dual_region_data_locations": ["us-east1","us-east4"], "region": "us" }
+  provision_params: { "storage_class": "NEARLINE", "placement_dual_region_data_locations": ["us-east1","us-east4"] }
   bind_params: { "role": "storage.objectAdmin" }


### PR DESCRIPTION
brokerpak tests currently fail with:

```
2024/06/26 10:49:28 (id=001): PUT http://5933ba03-bcae-4948-9255-c10fc6d95f2b:395053d5-a754-4029-a7b3-9e539c9418af@localhost:35627/v2/service_instances/2f9df846-3589-404b-bf7d-428c4bb18775?accepts_incomplete=true -> 500, "{\"description\":\"plan defined properties cannot be changed: region\"}\n"
2024/06/26 10:49:28 (id=001): Failed to provision csb-google-storage-bucket: unexpected response code 500
2024/06/26 10:49:28 (id=001): Cleaning up the environment
2024/06/26 10:49:28 (id=001): Unbinding csb-google-storage-bucket/gcp-bucket-multi-region (id: 20c6f1f8-9b65-43dd-9014-9b05fa4df417)
2024/06/26 10:49:28 (id=000): PUT http://5933ba03-bcae-4948-9255-c10fc6d95f2b:395053d5-a754-4029-a7b3-9e539c9418af@localhost:35627/v2/service_instances/ddbf8f93-c36f-436a-b8df-f3aeee18712b?accepts_incomplete=true -> 500, "{\"description\":\"plan defined properties cannot be changed: region\"}\n"
2024/06/26 10:49:28 (id=000): Failed to provision csb-google-storage-bucket: unexpected response code 500
2024/06/26 10:49:28 (id=000): Cleaning up the environment
```

this is because region was added to the plan to enable running these tests against a tile based deployment.

it is now specified twice and leads to above errors.

[#187498188]

### Checklist:

* [ ] Have you added Release Notes in the docs repositories?
* [ ] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

