### PR TITLE
feat: postgres support disk autoincrease #188071759

### DIFF
--- a/google-postgresql.yml
+++ b/google-postgresql.yml
@@ -39,13 +39,16 @@ provision:
     constraints:
       pattern: ^POSTGRES_[0-9]+$
   - field_name: storage_gb
-    required: true
     type: number
-    details: Size of storage volume for service instance.
+    details: Size of storage volume for service instance. Any attempt to change this value after the instance has been created will be ignored. All instances are created with auto storage increase enabled. 
     default: 10
     constraints:
       maximum: 4096
       minimum: 10
+  - field_name: storage_autoresize_limit
+    type: number
+    details: The maximum size to which storage capacity can be automatically increased. The default value is 0, which specifies that there is no limit.
+    default: 0
   - field_name: require_ssl
     type: boolean
     details: Allow only connections with valid client certificate

--- a/integration-tests/postgres_test.go
+++ b/integration-tests/postgres_test.go
@@ -114,7 +114,6 @@ var _ = Describe("postgres", Label("postgres"), func() {
 				Expect(err).NotTo(HaveOccurred())
 			},
 			Entry("tier", "tier", "db-g1-small"),
-			Entry("storage_gb", "storage_gb", 11),
 			Entry("authorized_network", "authorized_network", "new_network"),
 			Entry("authorized_network_id", "authorized_network_id", "new_network_id"),
 			Entry("authorized_networks_cidrs", "authorized_networks_cidrs", []string{"new cidr"}),

--- a/terraform-tests/postgres_test.go
+++ b/terraform-tests/postgres_test.go
@@ -22,6 +22,7 @@ var _ = Describe("postgres", Label("postgres-terraform"), Ordered, func() {
 	defaultVars := map[string]any{
 		"tier":                                  "db-n1-standard-2",
 		"storage_gb":                            10,
+		"storage_autoresize_limit":              50,
 		"credentials":                           googleCredentials,
 		"project":                               googleProject,
 		"instance_name":                         "test-instance-name-456",
@@ -81,7 +82,7 @@ var _ = Describe("postgres", Label("postgres-terraform"), Ordered, func() {
 								}),
 							),
 							"disk_autoresize":       BeTrue(),
-							"disk_autoresize_limit": BeNumerically("==", 0),
+							"disk_autoresize_limit": BeNumerically("==", 50),
 							"backup_configuration": ContainElement(
 								MatchKeys(IgnoreExtras, Keys{
 									"enabled":    BeTrue(),

--- a/terraform/cloudsql/postgresql/provision/main.tf
+++ b/terraform/cloudsql/postgresql/provision/main.tf
@@ -4,10 +4,10 @@ resource "google_sql_database_instance" "instance" {
   region           = var.region
 
   settings {
-    tier        = var.tier
-    disk_size   = var.storage_gb
+    tier                  = var.tier
+    disk_size             = var.storage_gb
     disk_autoresize_limit = var.storage_autoresize_limit
-    user_labels = var.labels
+    user_labels           = var.labels
 
     availability_type = local.availability_type
 
@@ -52,7 +52,7 @@ resource "google_sql_database_instance" "instance" {
 
   lifecycle {
     prevent_destroy = true
-    ignore_changes = [ 
+    ignore_changes = [
       // disk_size and disk_autoresize properties do not play along well together.
       // The value of disk_size will attempt override the resizing from disk_autoresize when that feature is enabled. 
       // This will cause an attempt to recreate the database instance.

--- a/terraform/cloudsql/postgresql/provision/variables.tf
+++ b/terraform/cloudsql/postgresql/provision/variables.tf
@@ -9,6 +9,7 @@ variable "db_name" { type = string }
 variable "region" { type = string }
 variable "labels" { type = map(any) }
 variable "storage_gb" { type = number }
+variable "storage_autoresize_limit" { type = number }
 variable "database_version" { type = string }
 variable "backups_retain_number" { type = number }
 variable "backups_location" { type = string }


### PR DESCRIPTION
Ideally, we would like to fully support both the `disk_gb` and the `disk_autoincrease` properties, but it is currently impossible because of OpenTofu inflexibility regarding the `lifecycle.ignore_changes`. See open issue https://github.com/opentofu/opentofu/issues/1432

This solution provides the ability to supply any storage size during creation, but any subsequent change to the `storage_gb` property will be ignored. The customer can still change the storage size via the console and that would be reflected in out TF state in the next operation.
This solution allows for the auto increase feature to work and OpenTofu will not attempt to override the storage value with the `storage_gb` property.

[#188071759](https://www.pivotaltracker.com/story/show/188071759]

### Checklist:

* [ ] Have you added Release Notes in the docs repositories?
* [ ] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

