### PR TITLE
feat: use operator ~> as version constraint

### DIFF
--- a/terraform/bigquery/bind/versions.tf
+++ b/terraform/bigquery/bind/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     google = {
       source  = "registry.terraform.io/hashicorp/google"
-      version = ">=4.8.0"
+      version = "~> 5"
     }
   }
 }

--- a/terraform/bigquery/provision/versions.tf
+++ b/terraform/bigquery/provision/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     google = {
       source  = "registry.terraform.io/hashicorp/google"
-      version = ">=4.8.0"
+      version = "~> 5"
     }
   }
 }

--- a/terraform/cloudsql/mysql/bind/versions.tf
+++ b/terraform/cloudsql/mysql/bind/versions.tf
@@ -6,7 +6,7 @@ terraform {
     }
     random = {
       source  = "registry.terraform.io/hashicorp/random"
-      version = ">=3.1.0"
+      version = "~> 3"
     }
   }
 }

--- a/terraform/cloudsql/mysql/provision/versions.tf
+++ b/terraform/cloudsql/mysql/provision/versions.tf
@@ -2,11 +2,11 @@ terraform {
   required_providers {
     google = {
       source  = "registry.terraform.io/hashicorp/google"
-      version = ">=4.8.0"
+      version = "~> 5"
     }
     random = {
       source  = "registry.terraform.io/hashicorp/random"
-      version = ">=3.4.3"
+      version = "~> 3"
     }
   }
 }

--- a/terraform/cloudsql/postgresql/bind/versions.tf
+++ b/terraform/cloudsql/postgresql/bind/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     random = {
       source  = "registry.terraform.io/hashicorp/random"
-      version = ">=3.1.0"
+      version = "~> 3"
     }
 
     csbpg = {

--- a/terraform/cloudsql/postgresql/provision/versions.tf
+++ b/terraform/cloudsql/postgresql/provision/versions.tf
@@ -2,12 +2,12 @@ terraform {
   required_providers {
     google = {
       source  = "registry.terraform.io/hashicorp/google"
-      version = ">=4.8.0"
+      version = "~> 5"
     }
 
     random = {
       source  = "registry.terraform.io/hashicorp/random"
-      version = ">=3.1.0"
+      version = "~> 3"
     }
   }
 }

--- a/terraform/dataproc/bind/versions.tf
+++ b/terraform/dataproc/bind/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     google = {
       source  = "registry.terraform.io/hashicorp/google"
-      version = ">=4.8.0"
+      version = "~> 5"
     }
   }
 }

--- a/terraform/dataproc/provision/versions.tf
+++ b/terraform/dataproc/provision/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     google = {
       source  = "registry.terraform.io/hashicorp/google"
-      version = ">=4.8.0"
+      version = "~> 5"
     }
   }
 }

--- a/terraform/redis/provision/versions.tf
+++ b/terraform/redis/provision/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     google = {
       source  = "registry.terraform.io/hashicorp/google"
-      version = ">=4.8.0"
+      version = "~> 5"
     }
   }
 }

--- a/terraform/spanner/bind/versions.tf
+++ b/terraform/spanner/bind/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     google = {
       source  = "registry.terraform.io/hashicorp/google"
-      version = ">=4.8.0"
+      version = "~> 5"
     }
   }
 }

--- a/terraform/spanner/provision/versions.tf
+++ b/terraform/spanner/provision/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     google = {
       source  = "registry.terraform.io/hashicorp/google"
-      version = ">=4.8.0"
+      version = "~> 5"
     }
   }
 }

--- a/terraform/stackdriver/bind/versions.tf
+++ b/terraform/stackdriver/bind/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     google = {
       source  = "registry.terraform.io/hashicorp/google"
-      version = ">=4.8.0"
+      version = "~> 5"
     }
   }
 }

--- a/terraform/storage/bind/versions.tf
+++ b/terraform/storage/bind/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     google = {
       source  = "registry.terraform.io/hashicorp/google"
-      version = ">=4.8.0"
+      version = "~> 5"
     }
   }
 }

--- a/terraform/storage/provision/versions.tf
+++ b/terraform/storage/provision/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     google = {
       source  = "registry.terraform.io/hashicorp/google"
-      version = ">=4.8.0"
+      version = "~> 5"
     }
   }
 }


### PR DESCRIPTION
The operator is a convenient shorthand that allows the rightmost component of a version to increment. The fix also corrects the Terraform test by downloading the current provider version.

### Checklist:

* [ ] Have you added Release Notes in the docs repositories?
* [ ] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

