### PR TITLE
chore: update Dependabot config for obsolete test app

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,13 +35,6 @@ updates:
     day: "saturday"
   labels:
     - "test-dependencies"
-- package-ecosystem: npm
-  directory: "/acceptance-tests/apps/stackdrivertraceapp"
-  schedule:
-    interval: "weekly"
-    day: "saturday"
-  labels:
-    - "test-dependencies"
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:


### PR DESCRIPTION
The stackdriver test app has been removed in a previous commit, and this change stops Dependabot from trying to keep it updated
