### PR TITLE
feat: MySQL should check client certificate

### DIFF
--- a/terraform/cloudsql/mysql/provision/main.tf
+++ b/terraform/cloudsql/mysql/provision/main.tf
@@ -17,6 +17,8 @@ resource "google_sql_database_instance" "instance" {
       ipv4_enabled    = var.public_ip
       private_network = local.authorized_network_id
 
+      ssl_mode = var.allow_insecure_connections ? "ALLOW_UNENCRYPTED_AND_ENCRYPTED" : "TRUSTED_CLIENT_CERTIFICATE_REQUIRED"
+
       dynamic "authorized_networks" {
         for_each = var.authorized_networks_cidrs
         iterator = networks


### PR DESCRIPTION
PostgreSQL checks client certificates. MySQL should do the same. Has additional benefit that in the GCP console it is reported that only TLS connections are accepted. (Currently only TLS connections are accepted because this is added as a setting to every user, but as it's not shown in the console, it can look like the database would accept insecure connections)
