### PR TITLE
chore: fix failures due to Go 1.24

### DIFF
--- a/acceptance-tests/helpers/apps/http.go
+++ b/acceptance-tests/helpers/apps/http.go
@@ -10,7 +10,11 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func (a *App) GET(format string, s ...any) Payload {
+func (a *App) GET(path string) Payload {
+	return a.GETf("%s", path)
+}
+
+func (a *App) GETf(format string, s ...any) Payload {
 	url := a.urlf(format, s...)
 	GinkgoWriter.Printf("HTTP GET: %s\n", url)
 	response, err := http.Get(url)
@@ -25,8 +29,12 @@ func (a *App) GET(format string, s ...any) Payload {
 	return Payload(data)
 }
 
-// GETResponse does an HTTP get, returning the *http.Response
-func (a *App) GETResponse(format string, s ...any) *http.Response {
+func (a *App) GETResponse(path string) *http.Response {
+	return a.GETResponsef("%s", path)
+}
+
+// GETResponsef does an HTTP get, returning the *http.Response
+func (a *App) GETResponsef(format string, s ...any) *http.Response {
 	GinkgoHelper()
 
 	url := a.urlf(format, s...)
@@ -36,7 +44,11 @@ func (a *App) GETResponse(format string, s ...any) *http.Response {
 	return response
 }
 
-func (a *App) PUT(data, format string, s ...any) {
+func (a *App) PUT(data, path string) {
+	a.PUTf(data, "%s", path)
+}
+
+func (a *App) PUTf(data, format string, s ...any) {
 	url := a.urlf(format, s...)
 	GinkgoWriter.Printf("HTTP PUT: %s\n", url)
 	GinkgoWriter.Printf("Sending data: %s\n", data)
@@ -48,7 +60,11 @@ func (a *App) PUT(data, format string, s ...any) {
 	Expect(response).To(HaveHTTPStatus(http.StatusCreated, http.StatusOK))
 }
 
-func (a *App) POST(data, format string, s ...any) Payload {
+func (a *App) POST(data, path string) Payload {
+	return a.POSTf(data, "%s", path)
+}
+
+func (a *App) POSTf(data, format string, s ...any) Payload {
 	url := a.urlf(format, s...)
 	GinkgoWriter.Printf("HTTP POST: %s\n", url)
 	GinkgoWriter.Printf("Sending data: %s\n", data)
@@ -76,7 +92,11 @@ func (a *App) DELETETestTable() {
 	Expect(response).To(HaveHTTPStatus(http.StatusGone, http.StatusNoContent))
 }
 
-func (a *App) DELETE(format string, s ...any) {
+func (a *App) DELETE(path string) {
+	a.DELETEf("%s", path)
+}
+
+func (a *App) DELETEf(format string, s ...any) {
 	url := a.urlf(format, s...)
 	GinkgoWriter.Printf("HTTP DELETE: %s\n", url)
 	request, err := http.NewRequest(http.MethodDelete, url, nil)

--- a/acceptance-tests/mysql_test.go
+++ b/acceptance-tests/mysql_test.go
@@ -50,11 +50,11 @@ var _ = Describe("MySQL", Label("mysql"), func() {
 		By("setting a key-value using the first app")
 		value := random.Hexadecimal()
 		var userIn appResponseUser
-		appOne.POST("", "?name=%s", value).ParseInto(&userIn)
+		appOne.POSTf("", "?name=%s", value).ParseInto(&userIn)
 
 		By("getting the value using the second app")
 		var userOut appResponseUser
-		appTwo.GET("%d", userIn.ID).ParseInto(&userOut)
+		appTwo.GETf("%d", userIn.ID).ParseInto(&userOut)
 		Expect(userOut.Name).To(Equal(value), "The first app stored [%s] as the value, the second app retrieved [%s]", value, userOut.Name)
 
 		By("verifying the first DB connection utilises TLS")
@@ -71,12 +71,12 @@ var _ = Describe("MySQL", Label("mysql"), func() {
 
 		By("verifying interactions with TLS enabled")
 		key, value := "key", "value"
-		golangApp.PUT(value, "/key-value/%s", key)
-		got := golangApp.GET("/key-value/%s", key).String()
+		golangApp.PUTf(value, "/key-value/%s", key)
+		got := golangApp.GETf("/key-value/%s", key).String()
 		Expect(got).To(Equal(value))
 
 		By("verifying that non-TLS connections should fail")
-		response := golangApp.GETResponse("/key-value/%s?tls=false", key)
+		response := golangApp.GETResponsef("/key-value/%s?tls=false", key)
 		defer response.Body.Close()
 		Expect(response).To(HaveHTTPStatus(http.StatusInternalServerError), "force TLS is enabled by default")
 		b, err := io.ReadAll(response.Body)
@@ -101,7 +101,7 @@ var _ = Describe("MySQL", Label("mysql"), func() {
 
 		By("ensuring encryption wasn't used")
 		var tlsCipher mySQLOption
-		appOne.GET("mysql-ssl").ParseInto(&tlsCipher)
+		appOne.GETf("mysql-ssl").ParseInto(&tlsCipher)
 
 		Expect(strings.ToLower(tlsCipher.Name)).To(Equal("ssl_cipher"))
 		Expect(tlsCipher.Value).To(BeEmpty(), "Expected Mysql connection for app %s not to be encrypted", appOne.Name)

--- a/acceptance-tests/postgresql_test.go
+++ b/acceptance-tests/postgresql_test.go
@@ -88,24 +88,24 @@ var _ = Describe("PostgreSQL", func() {
 
 			By("creating an entry using the first app")
 			value := random.Hexadecimal()
-			appOne.POST("", "?name=%s", value).ParseInto(&userIn)
+			appOne.POSTf("", "?name=%s", value).ParseInto(&userIn)
 
 			By("binding and starting the second app")
 			serviceInstance.Bind(appTwo)
 			apps.Start(appTwo)
 
 			By("getting the entry using the second app")
-			appTwo.GET("%d", userIn.ID).ParseInto(&userOut)
+			appTwo.GETf("%d", userIn.ID).ParseInto(&userOut)
 			Expect(userOut.Name).To(Equal(value), "The first app stored [%s] as the value, the second app retrieved [%s]", value, userOut.Name)
 
 			By("verifying the DB connection utilises TLS")
-			appOne.GET("postgres-ssl").ParseInto(&sslInfo)
+			appOne.GETf("postgres-ssl").ParseInto(&sslInfo)
 			Expect(sslInfo.SSL).To(BeTrue())
 			Expect(sslInfo.Cipher).NotTo(BeEmpty())
 			Expect(sslInfo.Bits).To(BeNumerically(">=", 256))
 
 			By("deleting the entry using the first app")
-			appOne.DELETE("%d", userIn.ID)
+			appOne.DELETEf("%d", userIn.ID)
 
 			By("triggering ownership management")
 			binding.Unbind()
@@ -113,15 +113,15 @@ var _ = Describe("PostgreSQL", func() {
 			By("setting another value using the second app")
 			var userInTwo AppResponseUser
 			value2 := random.Hexadecimal()
-			appTwo.POST("", "?name=%s", value2).ParseInto(&userInTwo)
+			appTwo.POSTf("", "?name=%s", value2).ParseInto(&userInTwo)
 
 			By("getting the entry using the second app")
 			var userOutTwo AppResponseUser
-			appTwo.GET("%d", userInTwo.ID).ParseInto(&userOutTwo)
+			appTwo.GETf("%d", userInTwo.ID).ParseInto(&userOutTwo)
 			Expect(userOut.Name).To(Equal(value), "The second app stored [%s] as the value, the second app retrieved [%s]", value, userOut.Name)
 
 			By("deleting the entry using the second app")
-			appTwo.DELETE("%d", userInTwo.ID)
+			appTwo.DELETEf("%d", userInTwo.ID)
 		})
 
 		It("works with the default postgres version", Label("postgresql"), func() {
@@ -150,7 +150,7 @@ var _ = Describe("PostgreSQL", func() {
 			By("setting a key-value using the first app")
 			key := random.Hexadecimal()
 			value := random.Hexadecimal()
-			appOne.PUT(value, "%s/%s", schema, key)
+			appOne.PUTf(value, "%s/%s", schema, key)
 
 			By("binding the second app to the service instance")
 			serviceInstance.Bind(appTwo)
@@ -159,23 +159,23 @@ var _ = Describe("PostgreSQL", func() {
 			apps.Start(appTwo)
 
 			By("getting the value using the second app")
-			got := appTwo.GET("%s/%s", schema, key).String()
+			got := appTwo.GETf("%s/%s", schema, key).String()
 			Expect(got).To(Equal(value))
 
 			By("triggering ownership of schema to pass to provision user")
 			binding.Unbind()
 
 			By("getting the value again using the second app")
-			got2 := appTwo.GET("%s/%s", schema, key).String()
+			got2 := appTwo.GETf("%s/%s", schema, key).String()
 			Expect(got2).To(Equal(value))
 
 			By("setting another value using the second app")
 			key2 := random.Hexadecimal()
 			value2 := random.Hexadecimal()
-			appTwo.PUT(value2, "%s/%s", schema, key2)
+			appTwo.PUTf(value2, "%s/%s", schema, key2)
 
 			By("getting the other value using the second app")
-			got3 := appTwo.GET("%s/%s", schema, key2).String()
+			got3 := appTwo.GETf("%s/%s", schema, key2).String()
 			Expect(got3).To(Equal(value2))
 
 			By("dropping the schema using the second app")

--- a/acceptance-tests/storage_test.go
+++ b/acceptance-tests/storage_test.go
@@ -73,12 +73,12 @@ var _ = Describe("Storage", Label("storage"), func() {
 		By("uploading a blob using the first app")
 		blobName := random.Hexadecimal()
 		blobData := random.Hexadecimal()
-		appOne.POST(blobData, "/storage/write?bucketName=%s&objectName=%s", bucketName, blobName)
+		appOne.POSTf(blobData, "/storage/write?bucketName=%s&objectName=%s", bucketName, blobName)
 
 		By("downloading the blob using the second app")
-		got := appTwo.GET("/storage/read?bucketName=%s&objectName=%s", bucketName, blobName).String()
+		got := appTwo.GETf("/storage/read?bucketName=%s&objectName=%s", bucketName, blobName).String()
 		Expect(got).To(Equal(blobData))
 
-		appOne.DELETE("/storage/delete?bucketName=%s&objectName=%s", bucketName, blobName)
+		appOne.DELETEf("/storage/delete?bucketName=%s&objectName=%s", bucketName, blobName)
 	})
 })

--- a/acceptance-tests/upgrade/update_and_upgrade_mysql_test.go
+++ b/acceptance-tests/upgrade/update_and_upgrade_mysql_test.go
@@ -57,10 +57,10 @@ var _ = Describe("UpgradeMYSQLTest", Label("mysql"), func() {
 			By("setting a key-value using the first app")
 			key := random.Hexadecimal()
 			value := random.Hexadecimal()
-			appOne.PUT(value, "/key-value/%s", key)
+			appOne.PUTf(value, "/key-value/%s", key)
 
 			By("getting the value using the second app")
-			Expect(appTwo.GET("/key-value/%s", key).String()).To(Equal(value))
+			Expect(appTwo.GETf("/key-value/%s", key).String()).To(Equal(value))
 
 			By("pushing the development version of the broker")
 			serviceBroker.UpdateBroker(developmentBuildDir)
@@ -72,7 +72,7 @@ var _ = Describe("UpgradeMYSQLTest", Label("mysql"), func() {
 			serviceInstance.Upgrade()
 
 			By("getting the value using the second app")
-			Expect(appTwo.GET("/key-value/%s", key).String()).To(Equal(value))
+			Expect(appTwo.GETf("/key-value/%s", key).String()).To(Equal(value))
 
 			By("deleting bindings created before the upgrade")
 			bindingOne.Unbind()
@@ -87,7 +87,7 @@ var _ = Describe("UpgradeMYSQLTest", Label("mysql"), func() {
 			serviceInstance.Update(services.WithParameters(`{}`))
 
 			By("getting the value using the second app")
-			Expect(appTwo.GET("/key-value/%s", key).String()).To(Equal(value))
+			Expect(appTwo.GETf("/key-value/%s", key).String()).To(Equal(value))
 
 			By("deleting bindings created before the update")
 			bindingOne.Unbind()
@@ -99,20 +99,20 @@ var _ = Describe("UpgradeMYSQLTest", Label("mysql"), func() {
 			apps.Restage(appOne, appTwo)
 
 			By("getting the value using the second app")
-			Expect(appTwo.GET("/key-value/%s", key).String()).To(Equal(value))
+			Expect(appTwo.GETf("/key-value/%s", key).String()).To(Equal(value))
 
 			By("checking data can still be written and read")
 			keyTwo := random.Hexadecimal()
 			valueTwo := random.Hexadecimal()
-			appOne.PUT(valueTwo, "/key-value/%s", keyTwo)
-			Expect(appTwo.GET("/key-value/%s", keyTwo).String()).To(Equal(valueTwo))
+			appOne.PUTf(valueTwo, "/key-value/%s", keyTwo)
+			Expect(appTwo.GETf("/key-value/%s", keyTwo).String()).To(Equal(valueTwo))
 
 			By("verifying the DB connection utilises TLS")
 			var sslInfo struct {
 				VariableName string `json:"variable_name"`
 				Value        string `json:"value"`
 			}
-			appOne.GET("/admin/ssl").ParseInto(&sslInfo)
+			appOne.GETf("/admin/ssl").ParseInto(&sslInfo)
 
 			Expect(sslInfo.VariableName).To(Equal("Ssl_cipher"))
 			Expect(sslInfo.Value).To(Equal("ECDHE-RSA-AES128-GCM-SHA256"))

--- a/acceptance-tests/upgrade/update_and_upgrade_postgresql_test.go
+++ b/acceptance-tests/upgrade/update_and_upgrade_postgresql_test.go
@@ -57,10 +57,10 @@ var _ = Describe("UpgradePostgreSQLTest", Label("postgresql"), func() {
 			By("setting a key-value using the first app")
 			keyOne := random.Hexadecimal()
 			valueOne := random.Hexadecimal()
-			appOne.PUT(valueOne, "%s/%s", schema, keyOne)
+			appOne.PUTf(valueOne, "%s/%s", schema, keyOne)
 
 			By("getting the value using the second app")
-			got := appTwo.GET("%s/%s", schema, keyOne).String()
+			got := appTwo.GETf("%s/%s", schema, keyOne).String()
 			Expect(got).To(Equal(valueOne))
 
 			By("pushing the development version of the broker")
@@ -73,7 +73,7 @@ var _ = Describe("UpgradePostgreSQLTest", Label("postgresql"), func() {
 			serviceInstance.Upgrade()
 
 			By("checking previously written data still accessible")
-			got = appTwo.GET("%s/%s", schema, keyOne).String()
+			got = appTwo.GETf("%s/%s", schema, keyOne).String()
 			Expect(got).To(Equal(valueOne))
 
 			By("deleting bindings created before the upgrade")
@@ -89,7 +89,7 @@ var _ = Describe("UpgradePostgreSQLTest", Label("postgresql"), func() {
 			serviceInstance.Update(services.WithParameters(`{}`))
 
 			By("checking previously written data still accessible")
-			got = appTwo.GET("%s/%s", schema, keyOne).String()
+			got = appTwo.GETf("%s/%s", schema, keyOne).String()
 			Expect(got).To(Equal(valueOne))
 
 			By("deleting bindings created before the update")
@@ -102,15 +102,15 @@ var _ = Describe("UpgradePostgreSQLTest", Label("postgresql"), func() {
 			apps.Restage(appOne, appTwo)
 
 			By("checking previously written data still accessible")
-			got = appTwo.GET("%s/%s", schema, keyOne).String()
+			got = appTwo.GETf("%s/%s", schema, keyOne).String()
 			Expect(got).To(Equal(valueOne))
 
 			By("checking data can still be written and read")
 			keyTwo := random.Hexadecimal()
 			valueTwo := random.Hexadecimal()
-			appOne.PUT(valueTwo, "%s/%s", schema, keyTwo)
+			appOne.PUTf(valueTwo, "%s/%s", schema, keyTwo)
 
-			got = appTwo.GET("%s/%s", schema, keyTwo).String()
+			got = appTwo.GETf("%s/%s", schema, keyTwo).String()
 			Expect(got).To(Equal(valueTwo))
 		})
 	})


### PR DESCRIPTION
Changes to integration tests to satisfy Go 1.24 new requirement for format strings to be constants.
