### PR TITLE
test: setting GCP_PAS_NETWORK should not be mandatory

### DIFF
--- a/acceptance-tests/helpers/brokers/env.go
+++ b/acceptance-tests/helpers/brokers/env.go
@@ -15,7 +15,7 @@ func (b *Broker) env() []apps.EnvVar {
 	for name, required := range map[string]bool{
 		"GOOGLE_CREDENTIALS":                     true,
 		"GOOGLE_PROJECT":                         true,
-		"GCP_PAS_NETWORK":                        true,
+		"GCP_PAS_NETWORK":                        false,
 		"GSB_BROKERPAK_BUILTIN_PATH":             false,
 		"GSB_PROVISION_DEFAULTS":                 false,
 		"CH_CRED_HUB_URL":                        false,


### PR DESCRIPTION
Removes the enforcement of setting GCP_PAS_NETWORK which is practice is not used in the tests or by the product (it's used in Makefiles which are not run in the tests)