### PR TITLE
chore: apply fixes from Go modernize command

### DIFF
--- a/acceptance-tests/helpers/apps/prebuild.go
+++ b/acceptance-tests/helpers/apps/prebuild.go
@@ -23,7 +23,7 @@ func WithGoPreBuild(source string) Option {
 	Expect(err).NotTo(HaveOccurred())
 	Eventually(session, 5*time.Minute).Should(gexec.Exit(0))
 
-	err = os.WriteFile(path.Join(dir.path(), "Procfile"), []byte(fmt.Sprintf("web: ./%s\n", name)), 0555)
+	err = os.WriteFile(path.Join(dir.path(), "Procfile"), fmt.Appendf(nil, "web: ./%s\n", name), 0555)
 	Expect(err).NotTo(HaveOccurred())
 
 	return WithOptions(

--- a/acceptance-tests/helpers/brokers/envrc.go
+++ b/acceptance-tests/helpers/brokers/envrc.go
@@ -17,7 +17,7 @@ func readEnvrcServices(path string) (result []apps.EnvVar) {
 	data, err := os.ReadFile(path)
 	Expect(err).NotTo(HaveOccurred())
 
-	for _, line := range strings.Split(string(data), "\n") {
+	for line := range strings.SplitSeq(string(data), "\n") {
 		m := serviceMatcher.FindStringSubmatch(line)
 		const expectedNumberOfMatches = 3
 		if len(m) != expectedNumberOfMatches {


### PR DESCRIPTION
The modernize command replaces old constructs with simpler, updated ones.

Command is:
go run golang.org/x/tools/gopls/internal/analysis/modernize/cmd/modernize@latest -fix -test ./...

