### PR TITLE
test: TPE-14809: Add DB reachability smoke test before binding

### DIFF
--- a/acceptance-tests/upgrade/update_and_upgrade_mysql_test.go
+++ b/acceptance-tests/upgrade/update_and_upgrade_mysql_test.go
@@ -2,9 +2,11 @@ package upgrade_test
 
 import (
 	"fmt"
+	"strings"
 
 	"csbbrokerpakgcp/acceptance-tests/helpers/apps"
 	"csbbrokerpakgcp/acceptance-tests/helpers/brokers"
+	"csbbrokerpakgcp/acceptance-tests/helpers/cf"
 	"csbbrokerpakgcp/acceptance-tests/helpers/gcloud"
 	"csbbrokerpakgcp/acceptance-tests/helpers/matchers"
 	"csbbrokerpakgcp/acceptance-tests/helpers/plans"
@@ -52,6 +54,10 @@ var _ = Describe("UpgradeMYSQLTest", Label("mysql"), func() {
 			defer apps.Delete(appOne, appTwo)
 
 			By("binding the apps to the storage service instance")
+			ip := strings.TrimSpace(string(gcloud.GCP("sql", "instances", "describe", instanceName, "--format=value(ipAddresses[0].ipAddress)")))
+			By("verifying network reachability to the database at " + ip)
+			cf.Run("ssh", serviceBroker.Name, "-c", fmt.Sprintf("nc -zvw 10 %s 3306", ip))
+
 			bindingOne := serviceInstance.Bind(appOne)
 			bindingTwo := serviceInstance.Bind(appTwo)
 

--- a/acceptance-tests/upgrade/update_and_upgrade_postgresql_test.go
+++ b/acceptance-tests/upgrade/update_and_upgrade_postgresql_test.go
@@ -3,9 +3,13 @@ package upgrade_test
 import (
 	"csbbrokerpakgcp/acceptance-tests/helpers/apps"
 	"csbbrokerpakgcp/acceptance-tests/helpers/brokers"
+	"csbbrokerpakgcp/acceptance-tests/helpers/cf"
+	"csbbrokerpakgcp/acceptance-tests/helpers/gcloud"
 	"csbbrokerpakgcp/acceptance-tests/helpers/plans"
 	"csbbrokerpakgcp/acceptance-tests/helpers/random"
 	"csbbrokerpakgcp/acceptance-tests/helpers/services"
+	"fmt"
+	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -44,6 +48,11 @@ var _ = Describe("UpgradePostgreSQLTest", Label("postgresql"), func() {
 			defer apps.Delete(appOne, appTwo)
 
 			By("binding to the apps")
+			instanceName := fmt.Sprintf("csb-postgres-%s", serviceInstance.GUID())
+			ip := strings.TrimSpace(string(gcloud.GCP("sql", "instances", "describe", instanceName, "--format=value(ipAddresses[0].ipAddress)")))
+			By("verifying network reachability to the database at " + ip)
+			cf.Run("ssh", serviceBroker.Name, "-c", fmt.Sprintf("nc -zvw 10 %s 5432", ip))
+
 			bindingOne := serviceInstance.Bind(appOne)
 			bindingTwo := serviceInstance.Bind(appTwo)
 


### PR DESCRIPTION
Added a netcat test run from the broker CF container to the
private IP of the newly provisioned Cloud SQL database. This splits
the failure domain to prove whether the bind timeout is a network
issue or a broker logic issue.

ai-assisted=yes

Made with [Cursor](https://cursor.com)