### PR TITLE
TNZ-94778: chore: Update OpenTofu to 1.11.6

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -12,11 +12,11 @@ terraform_state_provider_replacements:
   registry.terraform.io/cloud-service-broker/csbpg: "cloudfoundry.org/cloud-service-broker/csbpg"
   registry.terraform.io/cloud-service-broker/csbmysql: "cloudfoundry.org/cloud-service-broker/csbmysql"
 terraform_upgrade_path:
-- version: 1.10.9
+- version: 1.11.6
 terraform_binaries:
 - name: tofu
-  version: 1.10.9
-  source: https://github.com/opentofu/opentofu/archive/v1.10.9.zip
+  version: 1.11.6
+  source: https://github.com/opentofu/opentofu/archive/v1.11.6.zip
   default: true
 - name: terraform-provider-google
   version: 7.29.0


### PR DESCRIPTION
## Summary
- Update OpenTofu minor version from 1.10.9 to 1.11.6 to stay current with upstream releases.
- The CI will continue to automatically bump patch versions for the 1.11.x line.

ai-assisted=yes

Made with [Cursor](https://cursor.com)