### PR TITLE
TNZ-102533: Add deletion_policy assertion in terraform tests

### DIFF
--- a/terraform-tests/mysql_test.go
+++ b/terraform-tests/mysql_test.go
@@ -77,6 +77,7 @@ var _ = Describe("mysql", Label("mysql-terraform"), Ordered, func() {
 					"database_version":              Equal("8.0"),
 					"region":                        Equal("us-central1"),
 					"deletion_protection":           BeFalse(),
+					"deletion_policy":               Equal("DELETE"),
 					"root_password":                 BeNil(),
 					"root_password_wo":              BeNil(),
 					"root_password_wo_version":      BeNil(),

--- a/terraform-tests/postgres_test.go
+++ b/terraform-tests/postgres_test.go
@@ -80,6 +80,7 @@ var _ = Describe("postgres", Label("postgres-terraform"), Ordered, func() {
 					"database_version":              Equal("POSTGRES_13"),
 					"region":                        Equal("us-central1"),
 					"deletion_protection":           BeFalse(),
+					"deletion_policy":               Equal("DELETE"),
 					"root_password":                 BeNil(),
 					"root_password_wo":              BeNil(),
 					"root_password_wo_version":      BeNil(),


### PR DESCRIPTION
## Summary
* Updated `terraform-tests/mysql_test.go` and `terraform-tests/postgres_test.go` to assert the `deletion_policy` is correctly set.
* This addresses a failure introduced by HashiCorp Google provider `v7.36.0` which now defaults `deletion_policy` to `"DELETE"`.

## Test plan
* Ensure the automated `terraform-tests` pipeline passes with the new provider changes.

Made with [Cursor](https://cursor.com)