### PR TITLE
TNZ-102533: Fix failing terraform tests due to deletion_policy

### DIFF
--- a/terraform-tests/mysql_test.go
+++ b/terraform-tests/mysql_test.go
@@ -76,6 +76,7 @@ var _ = Describe("mysql", Label("mysql-terraform"), Ordered, func() {
 					"name":                          Equal("test-instance-name-456"),
 					"database_version":              Equal("8.0"),
 					"region":                        Equal("us-central1"),
+					"deletion_policy":               Equal("DELETE"),
 					"deletion_protection":           BeFalse(),
 					"root_password":                 BeNil(),
 					"root_password_wo":              BeNil(),

--- a/terraform-tests/postgres_test.go
+++ b/terraform-tests/postgres_test.go
@@ -79,6 +79,7 @@ var _ = Describe("postgres", Label("postgres-terraform"), Ordered, func() {
 					"name":                          Equal("test-instance-name-456"),
 					"database_version":              Equal("POSTGRES_13"),
 					"region":                        Equal("us-central1"),
+					"deletion_policy":               Equal("DELETE"),
 					"deletion_protection":           BeFalse(),
 					"root_password":                 BeNil(),
 					"root_password_wo":              BeNil(),


### PR DESCRIPTION
## Summary
* Fix `terraform-tests` asserting on `deletion_policy` missing keys.
* The latest Terraform Google provider introduced `deletion_policy` to `google_sql_database_instance` and `google_sql_database` which broke `MatchAllKeys` tests.
* Added `deletion_policy` to expected keys for MySQL and Postgres default tests.

## Test plan
* Ensure the tests pass locally or in CI with the latest Google provider.